### PR TITLE
Release to layer-sdk-dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ venv/
 
 # make outputs
 .install.stamp
+
+catboost_info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
-name = "layer"
-version = "0.9.0"
+name = "layer-sdk-dev"
+version = "0.10.0"
 description = "Layer AI SDK"
 authors = ["Layer <info@layer.ai>"]
 readme = "DESCRIPTION.md"


### PR DESCRIPTION
Temporarily release to `layer-sdk-dev` so we can try the package before we do the switch over.

I've also populated the secrets in Github Actions. The releases were failing until now.