### PR TITLE
Create github releases for each pypi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,4 +63,13 @@ jobs:
           files_separator: ','
       - name: Publish
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: make publish PYPI_USER=${{ secrets.PYPI_USER }} PYPI_PASSWORD=${{ secrets.PYPI_PASSWORD }} PATCH_VERSION=${GITHUB_RUN_ID}
+        id: publish
+        run: |
+          make publish PYPI_USER=${{ secrets.PYPI_USER }} PYPI_PASSWORD=${{ secrets.PYPI_PASSWORD }} PATCH_VERSION=${GITHUB_RUN_ID}
+          BASE_VERSION=$(poetry version --short | sed 's/\.[0-9]$//g')
+          echo "::set-output name=version::${BASE_VERSION}.${GITHUB_RUN_ID}"
+      - name: Create Github Release
+        if: steps.publish.outcome == 'success'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.publish.outputs.version }}


### PR DESCRIPTION
This will simplify pulling the correct test code in `monorepo` also resolves https://linear.app/layer/issue/LAY-3086/script-to-get-commit-from-an-sdk-version