### PR TITLE
SDK M1 tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,20 @@ This repo uses `make` as the build system. The following targets can be used thr
 - `clean` - cleans the repo, including the `poetry` virtual environment
 - `help` - prints all targets
 
+### Python setup
+We recommend using `pyenv`
+
+Please run `pyenv install` in the root of this repository to setup the recommended python version.
+
+If you are using an M1 machine, we recommend using `conda`. Please run
+
+```
+conda create -yq -n sdk python=3.8 tokenizers==0.12.1 xgboost==1.5.1 lightgbm==3.3.2 poetry h5py==3.6.0 pyarrow==7.0.0
+conda activate sdk
+```
+
+After that you should be able to run the rest of the `make` targets as normal
+
 #### Installation
 
 You can install `layerai/sdk` from the root of this repository with:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2025,6 +2025,35 @@ tensorflow-gpu = ["tensorflow-gpu (>=2.8.0,<2.9.0)"]
 tensorflow-rocm = ["tensorflow-rocm (>=2.8.0,<2.9.0)"]
 
 [[package]]
+name = "tensorflow-macos"
+version = "2.8.0"
+description = "TensorFlow is an open source machine learning framework for everyone."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+absl-py = ">=0.4.0"
+astunparse = ">=1.6.0"
+flatbuffers = ">=1.12"
+gast = ">=0.2.1"
+google-pasta = ">=0.1.1"
+grpcio = ">=1.24.3,<2.0"
+h5py = ">=2.9.0"
+keras = ">=2.8.0rc0,<2.9"
+keras-preprocessing = ">=1.1.1"
+libclang = ">=9.0.1"
+numpy = ">=1.20"
+opt-einsum = ">=2.3.2"
+protobuf = ">=3.9.2"
+six = ">=1.12.0"
+tensorboard = ">=2.8,<2.9"
+termcolor = ">=1.1.0"
+tf-estimator-nightly = "2.8.0.dev2021122109"
+typing-extensions = ">=3.6.6"
+wrapt = ">=1.11.0"
+
+[[package]]
 name = "termcolor"
 version = "1.1.0"
 description = "ANSII Color formatting for output in terminal."
@@ -2441,7 +2470,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.11"
-content-hash = "2f62897e7d2a40c221ee3bb674108c3fa838e2c4cf4bc1c5db719daaf361d37a"
+content-hash = "bd3381bc62f7ba2262729966127e6a5a54b1081788c3e1f6b9c5b8c0f6759297"
 
 [metadata.files]
 absl-py = [
@@ -4159,6 +4188,11 @@ tensorflow-io-gcs-filesystem = [
     {file = "tensorflow_io_gcs_filesystem-0.25.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:660e4e837057c0ab96661f56a401bb14e8bc58c3a0d57c54383c3dc7c1a06119"},
     {file = "tensorflow_io_gcs_filesystem-0.25.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53611b66d7604976af2410502c05e1230fd1d856a18c5b391266d0bc9a1a14a6"},
     {file = "tensorflow_io_gcs_filesystem-0.25.0-cp39-cp39-win_amd64.whl", hash = "sha256:e7b15047cce35cd16fe4708ebe384c3a0077201cd2745e20df4204683c84e464"},
+]
+tensorflow-macos = [
+    {file = "tensorflow_macos-2.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:10c53c1331844bf9eba4dbf6de6c1fd94f7787df00582fb32f8f3f17f7b4c024"},
+    {file = "tensorflow_macos-2.8.0-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:53834b7d08e2e07f3e8b5821abfe87fdd693e54d97281f5fa8a626394bd6cd49"},
+    {file = "tensorflow_macos-2.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7f522e7b478f2bbd1707632edb0942e22df7878142c60316876fd0269a80d1e7"},
 ]
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ pytest = "^7.1.2"
 pytest-dotenv = "^0.5.2"
 flake8-no-implicit-concat = "^0.3.3"
 data-science-types = "0.2.23"
-tensorflow = "2.8.0"
+tensorflow = { version = "^2.8.0", markers = "platform_machine != 'arm64'" }
+tensorflow-macos = { version = "^2.8.0", markers = "platform_machine == 'arm64'" }
 catboost = "1.0.5"
 keras = "2.8.0"
 lightgbm = "3.3.2"


### PR DESCRIPTION
Pre-requirements for tests to work on M1

- Conda installed
- Conda environment created with `conda create -yq -n sdk-test python=3.8 tokenizers==0.12.1 xgboost==1.5.1 lightgbm==3.3.2 poetry h5py==3.6.0 pyarrow==7.0.0`
- `conda activate sdk-test`