### PR TITLE
Add check to ensure we keep the poetry lock up to date

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,27 @@ on:
   pull_request
 
 jobs:
+  check-lockfile:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Setup poetry
+        uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: 1.1.13
+      - name: Cache poetry virtualenvs
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/.cache/pypoetry/virtualenvs
+          key: poetry-vevns-${{ runner.os }}-3.8-${{ hashFiles('poetry.lock') }}
+      - name: Check lockfile
+        run: |
+          make install
+          poetry lock --no-update
+          [ -z "$(git status --porcelain=v1 2>/dev/null)" ] || (echo "Lock file is not up to date, please run 'poetry lock --no-update'" && exit 1)
   check:
     strategy:
       fail-fast: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ import layer
 
 The `poetry` documentation about dependency management is [here](https://python-poetry.org/docs/dependency-specification/)
 
-Every time you change dependencies, you should expect a corresponding change to `poetry.lock`. If you use `poetry` directly, it will be done automatically for you. If you manually edit `pyproject.toml`, you need to run `poetry lock` after.
+Every time you change dependencies, you should expect a corresponding change to `poetry.lock`. If you use `poetry` directly, it will be done automatically for you. If you manually edit `pyproject.toml`, you need to run `poetry lock --no-update` after.
 
 #### Poetry tips
 


### PR DESCRIPTION
A common mistake is editing the dependencies in `pyproject.toml` without updating the lock file. Adding a github check that guards against that.