### PR TITLE
Check that lockfile is updated on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,11 @@ jobs:
         with:
           path: /home/runner/.cache/pypoetry/virtualenvs
           key: poetry-vevns-${{ runner.os }}-3.8-${{ hashFiles('poetry.lock') }}
+      - name: Check lockfile
+        run: |
+          make install
+          poetry lock --no-update
+          [ -z "$(git status --porcelain=v1 2>/dev/null)" ] || (echo "Lock file is not up to date, please run 'poetry lock --no-update'" && exit 1)
       - name: Start the Datadog Agent
         uses: datadog/agent-github-action@v1
         with:


### PR DESCRIPTION
In https://github.com/layerai/sdk/pull/12 we've added the same check on PRs. However if two PRs both edit the lockfile, they can be green, but then the actual lockfile on `main` is not up to date.

Run the same check on `main` to ensure we catch that degenerate case.