### PR TITLE
Use sequence instead of tuple

### DIFF
--- a/layer/pandas_extensions.py
+++ b/layer/pandas_extensions.py
@@ -1,6 +1,6 @@
 import io
 import warnings
-from typing import Any, Generator, Iterable, Optional, Sequence, Tuple, Union
+from typing import Any, Generator, Iterable, Optional, Sequence, Union
 
 import numpy as np
 import PIL.Image
@@ -75,7 +75,7 @@ def _load_image(binary: Union[pa.BinaryScalar, pa.ExtensionScalar]) -> Image:
 
 
 class Images(ExtensionArray):
-    def __init__(self, images: Tuple[Image, ...]):
+    def __init__(self, images: Sequence[Image]):
         self._images = images
         self._dtype = _ImageDtype()
 
@@ -87,7 +87,7 @@ class Images(ExtensionArray):
         dtype: Optional[ExtensionDtype] = None,
         copy: bool = False,
     ) -> "Images":
-        return Images(tuple(scalars))
+        return Images(scalars)
 
     @property
     def dtype(self) -> ExtensionDtype:
@@ -132,12 +132,11 @@ class Images(ExtensionArray):
         return 0
 
     def __eq__(self, other: Any) -> np.ndarray:  # type: ignore
-        size = len(self._images)
-        eq_arr = np.empty(size, dtype=bool)
+        eq_arr = np.empty(len(self), dtype=bool)
         eq_arr.fill(False)
         if not isinstance(other, Images):
             return eq_arr
-        for i in range(min(size, len(other))):
+        for i in range(min(len(self), len(other))):
             if _image_bytes(self._images[i]) == _image_bytes(other._images[i]):
                 eq_arr[i] = True
         return eq_arr

--- a/test/unit/test_pandas_extensions.py
+++ b/test/unit/test_pandas_extensions.py
@@ -57,7 +57,7 @@ def test_pandas_images_head():
     ],
 )
 def test_pandas_images_reduce(reduce_func, result):
-    images = layer.Images(tuple(_generate_image(n) for n in range(0, 3)))
+    images = layer.Images([_generate_image(n) for n in range(0, 3)])
     assert images._reduce(reduce_func) == result
 
 
@@ -154,7 +154,7 @@ def test_images_eq_length_do_not_match_self():
 
 def _image_data_frame(num_images: int) -> pd.DataFrame:
     return pd.DataFrame(
-        {"image": layer.Images(tuple(_generate_image(n) for n in range(num_images)))}
+        {"image": layer.Images([_generate_image(n) for n in range(num_images)])}
     )
 
 


### PR DESCRIPTION
Do not require `Tuple[Image, ...]` in `Images.__init__`.

The `Tuple` requirement now implies the data should be always copied, which might not always be efficient. Loosen the restriction by requiring only `Sequence[Image]` instead, as only `len` and `__get_item__` implementations are required for conversions.
