### PR TITLE
Concat same type for pandas Images

### DIFF
--- a/layer/pandas_extensions.py
+++ b/layer/pandas_extensions.py
@@ -1,4 +1,5 @@
 import io
+import itertools
 import warnings
 from typing import Any, Generator, Iterable, Optional, Sequence, Union
 
@@ -88,6 +89,10 @@ class Images(ExtensionArray):
         copy: bool = False,
     ) -> "Images":
         return Images(scalars)
+
+    @classmethod
+    def _concat_same_type(cls, to_concat: Sequence["Images"]) -> "Images":
+        return Images(tuple(itertools.chain(*to_concat)))
 
     @property
     def dtype(self) -> ExtensionDtype:

--- a/test/unit/test_pandas_extensions.py
+++ b/test/unit/test_pandas_extensions.py
@@ -152,6 +152,25 @@ def test_images_eq_length_do_not_match_self():
     assert comp.tolist() == [True]
 
 
+def test_concat_same_type():
+    image0 = _generate_image(0)
+    image1 = _generate_image(1)
+    image2 = _generate_image(2)
+
+    images = Images._concat_same_type(
+        [
+            (image0,),
+            (
+                image1,
+                image2,
+            ),
+        ]
+    )
+    comp = Images((image0, image1, image2)).__eq__(images)
+
+    assert comp.tolist() == [True, True, True]
+
+
 def _image_data_frame(num_images: int) -> pd.DataFrame:
     return pd.DataFrame(
         {"image": layer.Images([_generate_image(n) for n in range(num_images)])}


### PR DESCRIPTION
Implement concat same type for pandas `Images`. Pandas might call this method for larger data frames.