### PR TITLE
Pin docker to v4 to ensure we don't pull a vulnerable pywin32 version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -739,20 +739,21 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "docker"
-version = "5.0.3"
+version = "4.4.4"
 description = "A Python library for the Docker Engine API."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
 pywin32 = {version = "227", markers = "sys_platform == \"win32\""}
 requests = ">=2.14.2,<2.18.0 || >2.18.0"
+six = ">=1.4.0"
 websocket-client = ">=0.32.0"
 
 [package.extras]
 ssh = ["paramiko (>=2.4.2)"]
-tls = ["pyOpenSSL (>=17.5.0)", "cryptography (>=3.4.7)", "idna (>=2.0.0)"]
+tls = ["pyOpenSSL (>=17.5.0)", "cryptography (>=1.3.4)", "idna (>=2.0.0)"]
 
 [[package]]
 name = "entrypoints"
@@ -2854,7 +2855,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.11"
-content-hash = "779ff56468746724eb74bdb976e4f160d24ee7035860efbc979956b23c566c27"
+content-hash = "9576d4ab426e0ddff1be395acb5a253bbc55ab93599bddf9380de0ad7f8ff553"
 
 [metadata.files]
 absl-py = [
@@ -3231,8 +3232,8 @@ dill = [
     {file = "dill-0.3.5.1.tar.gz", hash = "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"},
 ]
 docker = [
-    {file = "docker-5.0.3-py2.py3-none-any.whl", hash = "sha256:7a79bb439e3df59d0a72621775d600bc8bc8b422d285824cb37103eab91d1ce0"},
-    {file = "docker-5.0.3.tar.gz", hash = "sha256:d916a26b62970e7c2f554110ed6af04c7ccff8e9f81ad17d0d40c75637e227fb"},
+    {file = "docker-4.4.4-py2.py3-none-any.whl", hash = "sha256:f3607d5695be025fa405a12aca2e5df702a57db63790c73b927eb6a94aac60af"},
+    {file = "docker-4.4.4.tar.gz", hash = "sha256:d3393c878f575d3a9ca3b94471a3c89a6d960b35feb92f033c0de36cc9d934db"},
 ]
 entrypoints = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ humanize  = ">=3.11.0"
 idna = "<3"
 jsonschema = "3.1.1"
 mlflow  = ">=1.25.0"
+docker = "^4" # comes from mlflow, docker v5 brings a vulnerable version of pywin32 which is strictly pinned
 networkx  = ">=2.5"
 packaging = "<=21.0"  # latest release (21.2) is causing version conflicts with pyparsing
 pandas = "1.3.5"


### PR DESCRIPTION
Resolves https://github.com/layerai/sdk/security/dependabot/2