### PR TITLE
Ensure removed dependencies get cleaned up from poetry vevn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ POETRY := $(shell command -v poetry 2> /dev/null)
 install: $(INSTALL_STAMP) ## Install dependencies
 $(INSTALL_STAMP): pyproject.toml poetry.lock
 	@if [ -z $(POETRY) ]; then echo "Poetry could not be found. See https://python-poetry.org/docs/"; exit 2; fi
-	$(POETRY) install
+	$(POETRY) install --remove-untracked
 	touch $(INSTALL_STAMP)
 
 .PHONY: test


### PR DESCRIPTION
By default poetry won't uninstall a package if it is completely removed as a dependency. Because of this, I almost deleted a required dependency in https://github.com/layerai/sdk/pull/35

Force poetry to remove packages and only use dependencies in the lock file.