### PR TITLE
Remove pillow dependency from SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ POETRY := $(shell command -v poetry 2> /dev/null)
 install: $(INSTALL_STAMP) ## Install dependencies
 $(INSTALL_STAMP): pyproject.toml poetry.lock
 	@if [ -z $(POETRY) ]; then echo "Poetry could not be found. See https://python-poetry.org/docs/"; exit 2; fi
-	$(POETRY) install --remove-untracked
+	$(POETRY) install
 	touch $(INSTALL_STAMP)
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ POETRY := $(shell command -v poetry 2> /dev/null)
 install: $(INSTALL_STAMP) ## Install dependencies
 $(INSTALL_STAMP): pyproject.toml poetry.lock
 	@if [ -z $(POETRY) ]; then echo "Poetry could not be found. See https://python-poetry.org/docs/"; exit 2; fi
-	$(POETRY) install
+	$(POETRY) install --remove-untracked
 	touch $(INSTALL_STAMP)
 
 .PHONY: test

--- a/poetry.lock
+++ b/poetry.lock
@@ -1660,7 +1660,7 @@ python-versions = "*"
 name = "pillow"
 version = "9.1.1"
 description = "Python Imaging Library (Fork)"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -2855,7 +2855,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.11"
-content-hash = "36cebbaf8893e840a92e91cd259fa102da06ecb4ae19e365ec7ec145ef48300b"
+content-hash = "9334ed8348d47af804d60bc11759f960bd1d620760aceee38537f8eec6ba5ca1"
 
 [metadata.files]
 absl-py = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ docker = "^4" # comes from mlflow, docker v5 brings a vulnerable version of pywi
 networkx  = ">=2.5"
 packaging = "<=21.0"  # latest release (21.2) is causing version conflicts with pyparsing
 pandas = "1.3.5"
-Pillow = ">=9.1.0"
 pickle5 = { version = "~0.0.11", python = "<3.8" }
 polling  = ">=0.3.1"
 prompt_toolkit  = ">=3.0.8"


### PR DESCRIPTION
Remove pillow dependency from SDK, to avoid unnecessary version constraint conflicts. Only instance checks are made on `PIL`.