### PR TITLE
Add Pillow dependency to the images e2e test

### DIFF
--- a/test/e2e/test_pandas_images_dataset.py
+++ b/test/e2e/test_pandas_images_dataset.py
@@ -8,13 +8,14 @@ from PIL.Image import Image
 
 import layer
 from layer.contracts.projects import Project
-from layer.decorators import dataset
+from layer.decorators import dataset, pip_requirements
 
 
 def test_pandas_images_dataset_store_and_save(
     initialized_project: Project, asserter: E2ETestAsserter
 ):
     @dataset("images")
+    @pip_requirements(packages=["Pillow==9.1.1"])
     def build_images() -> pd.DataFrame:
         def _generate_image(n: int) -> Image:
             image = PIL.Image.new("RGB", (160, 40), color=(73, 109, 137))


### PR DESCRIPTION
Add Pillow dependency to the images e2e test to be able to remove it from the python runtime in the backend.