### PR TITLE
Add model prediction API

### DIFF
--- a/layer/clients/model_catalog.py
+++ b/layer/clients/model_catalog.py
@@ -3,8 +3,9 @@ import warnings
 from contextlib import contextmanager
 from logging import Logger
 from pathlib import Path
-from typing import Dict, Iterator, Optional
+from typing import Callable, Dict, Iterator, Optional, Tuple
 
+import pandas as pd
 from layerapi.api.entity.model_pb2 import Model as PBModel
 from layerapi.api.entity.model_train_pb2 import ModelTrain as PBModelTrain
 from layerapi.api.entity.model_train_status_pb2 import (
@@ -176,12 +177,12 @@ class ModelCatalogClient:
         )
         return response.id
 
-    def load_model_artifact(
+    def load_model(
         self,
         model: Model,
         state: ResourceTransferState,
         no_cache: bool = False,
-    ) -> ModelArtifact:
+    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
         """
         Loads a model artifact from the model catalog
 
@@ -213,7 +214,9 @@ class ModelCatalogClient:
         except Exception as ex:
             raise LayerClientException(f"Error while loading model, {ex}")
 
-    def _load_model(self, model: Model, model_dir: Path) -> ModelArtifact:
+    def _load_model(
+        self, model: Model, model_dir: Path
+    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
             return model.flavor.load_model_from_directory(model_dir)

--- a/layer/clients/model_catalog.py
+++ b/layer/clients/model_catalog.py
@@ -44,7 +44,7 @@ from layerapi.api.value.source_code_pb2 import RemoteFileLocation, SourceCode
 
 from layer.cache.cache import Cache
 from layer.config import ClientConfig
-from layer.contracts.models import Model, ModelArtifact, TrainStorageConfiguration
+from layer.contracts.models import Model, ModelObject, TrainStorageConfiguration
 from layer.contracts.runs import ModelFunctionDefinition, ResourceTransferState
 from layer.exceptions.exceptions import LayerClientException
 from layer.flavors.base import ModelRuntimeObjects
@@ -221,19 +221,19 @@ class ModelCatalogClient:
             warnings.simplefilter("ignore", category=UserWarning)
             return model.flavor.load_model_from_directory(model_dir)
 
-    def save_model_artifact(
+    def save_model_object(
         self,
         model: Model,
-        model_artifact: ModelArtifact,
+        model_object: ModelObject,
         tracker: Optional[RunProgressTracker] = None,
-    ) -> ModelArtifact:
+    ) -> ModelObject:
         if not tracker:
             tracker = RunProgressTracker()
-        self._logger.debug(f"Storing given model {model_artifact} for {model.path}")
+        self._logger.debug(f"Storing given model {model_object} for {model.path}")
         try:
             with tempfile.TemporaryDirectory() as tmp:
                 local_path = Path(tmp) / "model"
-                model.flavor.save_model_to_directory(model_artifact, local_path)
+                model.flavor.save_model_to_directory(model_object, local_path)
                 state = ResourceTransferState()
                 tracker.mark_model_saving_result(model.name, state)
                 S3Util.upload_dir(
@@ -247,7 +247,7 @@ class ModelCatalogClient:
             raise LayerClientException(f"Error while storing model, {ex}")
         self._logger.debug(f"User model {model.path} saved successfully")
 
-        return model_artifact
+        return model_object
 
     def get_model_train_storage_configuration(
         self,

--- a/layer/contracts/models.py
+++ b/layer/contracts/models.py
@@ -10,7 +10,7 @@ from layerapi.api.value.s3_path_pb2 import S3Path
 
 from layer.exceptions.exceptions import LayerClientException
 from layer.flavors.base import ModelFlavor, ModelRuntimeObjects
-from layer.types import ModelArtifact
+from layer.types import ModelObject
 
 from .asset import AssetPath, AssetType, BaseAsset
 
@@ -91,12 +91,12 @@ class Model(BaseAsset):
         return self._storage_config
 
     @property
-    def artifact(self) -> ModelArtifact:
+    def artifact(self) -> ModelObject:
         if self._model_runtime_objects is None:
             raise LayerClientException("Model artifact is not yet fetched from storage")
-        return self._model_runtime_objects.model_artifact
+        return self._model_runtime_objects.model_object
 
-    def get_train(self) -> ModelArtifact:
+    def get_train(self) -> ModelObject:
         """
         Returns the trained and saved model artifact. For example, a scikit-learn or PyTorch model object.
 

--- a/layer/contracts/models.py
+++ b/layer/contracts/models.py
@@ -91,7 +91,7 @@ class Model(BaseAsset):
         return self._storage_config
 
     @property
-    def artifact(self) -> ModelObject:
+    def model_object(self) -> ModelObject:
         if self._model_runtime_objects is None:
             raise LayerClientException("Model artifact is not yet fetched from storage")
         return self._model_runtime_objects.model_object
@@ -102,7 +102,7 @@ class Model(BaseAsset):
 
         :return: The trained model artifact.
         """
-        return self.artifact
+        return self.model_object
 
     def predict(self, input_df: pd.DataFrame) -> pd.DataFrame:
         """

--- a/layer/flavors/base.py
+++ b/layer/flavors/base.py
@@ -1,7 +1,9 @@
 import inspect
 from abc import ABCMeta, abstractmethod, abstractproperty
 from pathlib import Path
+from typing import Callable, Tuple
 
+import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
@@ -64,7 +66,9 @@ class ModelFlavor(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def load_model_from_directory(self, directory: Path) -> ModelArtifact:
+    def load_model_from_directory(
+        self, directory: Path
+    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
         """Defines the method that this Model Flavor uses to load a model from a directory.
 
         Returns:

--- a/layer/flavors/base.py
+++ b/layer/flavors/base.py
@@ -7,12 +7,12 @@ from typing import Callable, Optional
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
-from layer.types import ModelArtifact
+from layer.types import ModelObject
 
 
 @dataclass(frozen=True)
 class ModelRuntimeObjects:
-    model_artifact: ModelArtifact
+    model_object: ModelObject
     prediction_function: Optional[Callable[[pd.DataFrame], pd.DataFrame]] = None
 
 
@@ -41,16 +41,16 @@ class ModelFlavor(metaclass=ABCMeta):
             The proto flavor
         """
 
-    def can_interpret_object(self, model_artifact: ModelArtifact) -> bool:
+    def can_interpret_object(self, model_object: ModelObject) -> bool:
         """Checks whether supplied model object has flavor of this class.
 
         Args:
-            model_artifact: A machine learning model which could be originated from any framework.
+            model_object: A machine learning model which could be originated from any framework.
 
         Returns:
             bool: true if this ModelFlavor can interpret the given model instance.
         """
-        for hierarchy_class in inspect.getmro(type(model_artifact)):
+        for hierarchy_class in inspect.getmro(type(model_object)):
             parent_module = inspect.getmodule(hierarchy_class)
             if (
                 parent_module is not None
@@ -63,7 +63,7 @@ class ModelFlavor(metaclass=ABCMeta):
     @abstractmethod
     def save_model_to_directory(
         self,
-        model_artifact: ModelArtifact,
+        model_object: ModelObject,
         directory: Path,
     ) -> None:
         """Defines the method that this Model Flavor uses to save a model to a directory.

--- a/layer/flavors/base.py
+++ b/layer/flavors/base.py
@@ -1,12 +1,19 @@
 import inspect
 from abc import ABCMeta, abstractmethod, abstractproperty
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Tuple
+from typing import Callable, Optional
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
+
+
+@dataclass(frozen=True)
+class ModelRuntimeObjects:
+    model_artifact: ModelArtifact
+    prediction_function: Optional[Callable[[pd.DataFrame], pd.DataFrame]] = None
 
 
 class ModelFlavor(metaclass=ABCMeta):
@@ -66,9 +73,7 @@ class ModelFlavor(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def load_model_from_directory(
-        self, directory: Path
-    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
+    def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
         """Defines the method that this Model Flavor uses to load a model from a directory.
 
         Returns:

--- a/layer/flavors/catboost.py
+++ b/layer/flavors/catboost.py
@@ -4,7 +4,7 @@ from typing import Any
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
-from layer.types import ModelArtifact
+from layer.types import ModelObject
 
 from .base import ModelFlavor, ModelRuntimeObjects
 
@@ -16,7 +16,7 @@ class CatBoostModelFlavor(ModelFlavor):
     PROTO_FLAVOR = ModelVersion.ModelFlavor.MODEL_FLAVOR_CATBOOST
 
     def save_model_to_directory(
-        self, model_object: ModelArtifact, directory: Path
+        self, model_object: ModelObject, directory: Path
     ) -> None:
         import mlflow.catboost
 

--- a/layer/flavors/catboost.py
+++ b/layer/flavors/catboost.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from typing import Any, Callable, Tuple
+from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
 
-from .base import ModelFlavor
+from .base import ModelFlavor, ModelRuntimeObjects
 
 
 class CatBoostModelFlavor(ModelFlavor):
@@ -22,13 +22,13 @@ class CatBoostModelFlavor(ModelFlavor):
 
         mlflow.catboost.save_model(model_object, path=directory.as_posix())
 
-    def load_model_from_directory(
-        self, directory: Path
-    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
+    def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
         import mlflow.catboost
 
         model = mlflow.catboost.load_model(directory.as_uri())
-        return model, lambda input_df: self.__predict(model, input_df)
+        return ModelRuntimeObjects(
+            model, lambda input_df: self.__predict(model, input_df)
+        )
 
     @staticmethod
     def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:

--- a/layer/flavors/catboost.py
+++ b/layer/flavors/catboost.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
@@ -31,6 +30,6 @@ class CatBoostModelFlavor(ModelFlavor):
         )
 
     @staticmethod
-    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
-        prediction_np_array = model.predict(input_df)
+    def __predict(model: ModelObject, input_df: pd.DataFrame) -> pd.DataFrame:
+        prediction_np_array = model.predict(input_df)  # type: ignore
         return pd.DataFrame(prediction_np_array, columns=["prediction"])

--- a/layer/flavors/catboost.py
+++ b/layer/flavors/catboost.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from typing import Any, Callable, Tuple
 
+import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
@@ -20,7 +22,15 @@ class CatBoostModelFlavor(ModelFlavor):
 
         mlflow.catboost.save_model(model_object, path=directory.as_posix())
 
-    def load_model_from_directory(self, directory: Path) -> ModelArtifact:
+    def load_model_from_directory(
+        self, directory: Path
+    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
         import mlflow.catboost
 
-        return mlflow.catboost.load_model(directory.as_uri())
+        model = mlflow.catboost.load_model(directory.as_uri())
+        return model, lambda input_df: self.__predict(model, input_df)
+
+    @staticmethod
+    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+        prediction_np_array = model.predict(input_df)
+        return pd.DataFrame(prediction_np_array, columns=["prediction"])

--- a/layer/flavors/huggingface.py
+++ b/layer/flavors/huggingface.py
@@ -1,6 +1,7 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Tuple
 
+import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
@@ -26,11 +27,19 @@ class HuggingFaceModelFlavor(ModelFlavor):
         with open(directory / self.HF_TYPE_FILE, "w") as f:
             f.write(type(model_object).__name__)
 
-    def load_model_from_directory(self, directory: Path) -> ModelArtifact:
+    def load_model_from_directory(
+        self, directory: Path
+    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
         with open(directory / self.HF_TYPE_FILE) as f:
             transformer_type = f.readlines()[0]
 
             mod = __import__("transformers", fromlist=[transformer_type])
             architecture_class = getattr(mod, transformer_type)
 
-            return architecture_class.from_pretrained(directory.as_posix())
+            model = architecture_class.from_pretrained(directory.as_posix())
+
+            return model, lambda input_df: self.__predict(model, input_df)
+
+    @staticmethod
+    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+        raise Exception("Not implemented")

--- a/layer/flavors/huggingface.py
+++ b/layer/flavors/huggingface.py
@@ -1,8 +1,9 @@
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
+
+from layer.types import ModelObject
 
 from .base import ModelFlavor, ModelRuntimeObjects
 
@@ -17,10 +18,10 @@ class HuggingFaceModelFlavor(ModelFlavor):
 
     def save_model_to_directory(
         self,
-        model_object: Any,
+        model_object: ModelObject,
         directory: Path,
     ) -> None:
-        model_object.save_pretrained(directory.as_posix())
+        model_object.save_pretrained(directory.as_posix())  # type: ignore
 
         with open(directory / self.HF_TYPE_FILE, "w") as f:
             f.write(type(model_object).__name__)
@@ -39,5 +40,5 @@ class HuggingFaceModelFlavor(ModelFlavor):
             )
 
     @staticmethod
-    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+    def __predict(model: ModelObject, input_df: pd.DataFrame) -> pd.DataFrame:
         raise Exception("Not implemented")

--- a/layer/flavors/huggingface.py
+++ b/layer/flavors/huggingface.py
@@ -1,12 +1,10 @@
 from pathlib import Path
-from typing import Any, Callable, Tuple
+from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
-from layer.types import ModelArtifact
-
-from .base import ModelFlavor
+from .base import ModelFlavor, ModelRuntimeObjects
 
 
 class HuggingFaceModelFlavor(ModelFlavor):
@@ -27,9 +25,7 @@ class HuggingFaceModelFlavor(ModelFlavor):
         with open(directory / self.HF_TYPE_FILE, "w") as f:
             f.write(type(model_object).__name__)
 
-    def load_model_from_directory(
-        self, directory: Path
-    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
+    def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
         with open(directory / self.HF_TYPE_FILE) as f:
             transformer_type = f.readlines()[0]
 
@@ -38,7 +34,9 @@ class HuggingFaceModelFlavor(ModelFlavor):
 
             model = architecture_class.from_pretrained(directory.as_posix())
 
-            return model, lambda input_df: self.__predict(model, input_df)
+            return ModelRuntimeObjects(
+                model, lambda input_df: self.__predict(model, input_df)
+            )
 
     @staticmethod
     def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:

--- a/layer/flavors/keras.py
+++ b/layer/flavors/keras.py
@@ -4,7 +4,7 @@ from typing import Any
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
-from layer.types import ModelArtifact
+from layer.types import ModelObject
 
 from .base import ModelFlavor, ModelRuntimeObjects
 
@@ -17,7 +17,7 @@ class KerasModelFlavor(ModelFlavor):
 
     TOKENIZER_FILE = "tokenizer.pickle"
 
-    def can_interpret_object(self, model_object: ModelArtifact) -> bool:
+    def can_interpret_object(self, model_object: ModelObject) -> bool:
         # Check if model is a tensorflow keras
         try:
             import tensorflow.keras.models  # type: ignore
@@ -48,7 +48,7 @@ class KerasModelFlavor(ModelFlavor):
         return False
 
     def save_model_to_directory(
-        self, model_object: ModelArtifact, directory: Path
+        self, model_object: ModelObject, directory: Path
     ) -> None:
         import cloudpickle  # type: ignore
         import keras

--- a/layer/flavors/keras.py
+++ b/layer/flavors/keras.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
@@ -81,7 +80,7 @@ class KerasModelFlavor(ModelFlavor):
             )
 
     @staticmethod
-    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+    def __predict(model: ModelObject, input_df: pd.DataFrame) -> pd.DataFrame:
         #  https://www.tensorflow.org/api_docs/python/tf/keras/Model#predict
-        predictions = model.predict(input_df)
+        predictions = model.predict(input_df)  # type: ignore
         return pd.DataFrame(predictions)

--- a/layer/flavors/keras.py
+++ b/layer/flavors/keras.py
@@ -82,4 +82,6 @@ class KerasModelFlavor(ModelFlavor):
 
     @staticmethod
     def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
-        raise Exception("Not implemented")
+        #  https://www.tensorflow.org/api_docs/python/tf/keras/Model#predict
+        predictions = model.predict(input_df)
+        return pd.DataFrame(predictions)

--- a/layer/flavors/lightgbm.py
+++ b/layer/flavors/lightgbm.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
@@ -36,5 +35,5 @@ class LightGBMModelFlavor(ModelFlavor):
         )
 
     @staticmethod
-    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+    def __predict(model: ModelObject, input_df: pd.DataFrame) -> pd.DataFrame:
         raise Exception("Not implemented")

--- a/layer/flavors/lightgbm.py
+++ b/layer/flavors/lightgbm.py
@@ -4,7 +4,7 @@ from typing import Any
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
-from layer.types import ModelArtifact
+from layer.types import ModelObject
 
 from .base import ModelFlavor, ModelRuntimeObjects
 
@@ -20,7 +20,7 @@ class LightGBMModelFlavor(ModelFlavor):
 
     def save_model_to_directory(
         self,
-        model_object: ModelArtifact,
+        model_object: ModelObject,
         directory: Path,
     ) -> None:
         import mlflow.lightgbm

--- a/layer/flavors/lightgbm.py
+++ b/layer/flavors/lightgbm.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from typing import Any, Callable, Tuple
 
+import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
@@ -25,7 +27,14 @@ class LightGBMModelFlavor(ModelFlavor):
 
         return mlflow.lightgbm.save_model(model_object, path=directory.as_posix())
 
-    def load_model_from_directory(self, directory: Path) -> ModelArtifact:
+    def load_model_from_directory(
+        self, directory: Path
+    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
         import mlflow.lightgbm
 
-        return mlflow.lightgbm.load_model(directory.as_uri())
+        model = mlflow.lightgbm.load_model(directory.as_uri())
+        return model, lambda input_df: self.__predict(model, input_df)
+
+    @staticmethod
+    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+        raise Exception("Not implemented")

--- a/layer/flavors/lightgbm.py
+++ b/layer/flavors/lightgbm.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from typing import Any, Callable, Tuple
+from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
 
-from .base import ModelFlavor
+from .base import ModelFlavor, ModelRuntimeObjects
 
 
 class LightGBMModelFlavor(ModelFlavor):
@@ -27,13 +27,13 @@ class LightGBMModelFlavor(ModelFlavor):
 
         return mlflow.lightgbm.save_model(model_object, path=directory.as_posix())
 
-    def load_model_from_directory(
-        self, directory: Path
-    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
+    def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
         import mlflow.lightgbm
 
         model = mlflow.lightgbm.load_model(directory.as_uri())
-        return model, lambda input_df: self.__predict(model, input_df)
+        return ModelRuntimeObjects(
+            model, lambda input_df: self.__predict(model, input_df)
+        )
 
     @staticmethod
     def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:

--- a/layer/flavors/pytorch.py
+++ b/layer/flavors/pytorch.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from typing import Any, Callable, Tuple
 
+import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
@@ -44,11 +46,18 @@ class PyTorchModelFlavor(ModelFlavor):
             model_object, path=directory.as_posix(), code_paths=models_module_path
         )
 
-    def load_model_from_directory(self, directory: Path) -> ModelArtifact:
+    def load_model_from_directory(
+        self, directory: Path
+    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
         import mlflow.pytorch
         import torch
 
-        return mlflow.pytorch.load_model(
+        model = mlflow.pytorch.load_model(
             directory.as_uri(),
             map_location=torch.device("cpu"),
         )
+        return model, lambda input_df: self.__predict(model, input_df)
+
+    @staticmethod
+    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+        raise Exception("Not implemented")

--- a/layer/flavors/pytorch.py
+++ b/layer/flavors/pytorch.py
@@ -60,4 +60,7 @@ class PyTorchModelFlavor(ModelFlavor):
 
     @staticmethod
     def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
-        raise Exception("Not implemented")
+        from mlflow.pytorch import _PyTorchWrapper
+
+        model = _PyTorchWrapper(model)
+        return model.predict(input_df)

--- a/layer/flavors/pytorch.py
+++ b/layer/flavors/pytorch.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
@@ -59,8 +58,8 @@ class PyTorchModelFlavor(ModelFlavor):
         )
 
     @staticmethod
-    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+    def __predict(model: ModelObject, input_df: pd.DataFrame) -> pd.DataFrame:
         from mlflow.pytorch import _PyTorchWrapper
 
         model = _PyTorchWrapper(model)
-        return model.predict(input_df)
+        return model.predict(input_df)  # type: ignore

--- a/layer/flavors/pytorch.py
+++ b/layer/flavors/pytorch.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from typing import Any, Callable, Tuple
+from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
 
-from .base import ModelFlavor
+from .base import ModelFlavor, ModelRuntimeObjects
 
 
 class PyTorchModelFlavor(ModelFlavor):
@@ -46,9 +46,7 @@ class PyTorchModelFlavor(ModelFlavor):
             model_object, path=directory.as_posix(), code_paths=models_module_path
         )
 
-    def load_model_from_directory(
-        self, directory: Path
-    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
+    def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
         import mlflow.pytorch
         import torch
 
@@ -56,7 +54,9 @@ class PyTorchModelFlavor(ModelFlavor):
             directory.as_uri(),
             map_location=torch.device("cpu"),
         )
-        return model, lambda input_df: self.__predict(model, input_df)
+        return ModelRuntimeObjects(
+            model, lambda input_df: self.__predict(model, input_df)
+        )
 
     @staticmethod
     def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:

--- a/layer/flavors/pytorch.py
+++ b/layer/flavors/pytorch.py
@@ -4,7 +4,7 @@ from typing import Any
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
-from layer.types import ModelArtifact
+from layer.types import ModelObject
 
 from .base import ModelFlavor, ModelRuntimeObjects
 
@@ -16,7 +16,7 @@ class PyTorchModelFlavor(ModelFlavor):
     PROTO_FLAVOR = ModelVersion.ModelFlavor.MODEL_FLAVOR_PYTORCH
 
     def save_model_to_directory(
-        self, model_object: ModelArtifact, directory: Path
+        self, model_object: ModelObject, directory: Path
     ) -> None:
         import mlflow.pytorch
 

--- a/layer/flavors/sklearn.py
+++ b/layer/flavors/sklearn.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from typing import Any, Callable, Tuple
 
+import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
@@ -23,7 +25,15 @@ class ScikitLearnModelFlavor(ModelFlavor):
             model_object, path=directory.as_posix(), serialization_format="pickle"
         )
 
-    def load_model_from_directory(self, directory: Path) -> ModelArtifact:
+    def load_model_from_directory(
+        self, directory: Path
+    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
         import mlflow.sklearn
 
-        return mlflow.sklearn.load_model(directory.as_uri())
+        model = mlflow.sklearn.load_model(directory.as_uri())
+        return model, lambda input_df: self.__predict(model, input_df)
+
+    @staticmethod
+    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+        prediction_np_array = model.predict(input_df)
+        return pd.DataFrame(prediction_np_array, columns=["prediction"])

--- a/layer/flavors/sklearn.py
+++ b/layer/flavors/sklearn.py
@@ -4,7 +4,7 @@ from typing import Any
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
-from layer.types import ModelArtifact
+from layer.types import ModelObject
 
 from .base import ModelFlavor, ModelRuntimeObjects
 
@@ -16,7 +16,7 @@ class ScikitLearnModelFlavor(ModelFlavor):
     PROTO_FLAVOR = ModelVersion.ModelFlavor.MODEL_FLAVOR_SKLEARN
 
     def save_model_to_directory(
-        self, model_object: ModelArtifact, directory: Path
+        self, model_object: ModelObject, directory: Path
     ) -> None:
         import mlflow.sklearn
 

--- a/layer/flavors/sklearn.py
+++ b/layer/flavors/sklearn.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
@@ -34,6 +33,6 @@ class ScikitLearnModelFlavor(ModelFlavor):
         )
 
     @staticmethod
-    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
-        prediction_np_array = model.predict(input_df)
+    def __predict(model: ModelObject, input_df: pd.DataFrame) -> pd.DataFrame:
+        prediction_np_array = model.predict(input_df)  # type: ignore
         return pd.DataFrame(prediction_np_array, columns=["prediction"])

--- a/layer/flavors/sklearn.py
+++ b/layer/flavors/sklearn.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from typing import Any, Callable, Tuple
+from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
 
-from .base import ModelFlavor
+from .base import ModelFlavor, ModelRuntimeObjects
 
 
 class ScikitLearnModelFlavor(ModelFlavor):
@@ -25,13 +25,13 @@ class ScikitLearnModelFlavor(ModelFlavor):
             model_object, path=directory.as_posix(), serialization_format="pickle"
         )
 
-    def load_model_from_directory(
-        self, directory: Path
-    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
+    def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
         import mlflow.sklearn
 
         model = mlflow.sklearn.load_model(directory.as_uri())
-        return model, lambda input_df: self.__predict(model, input_df)
+        return ModelRuntimeObjects(
+            model, lambda input_df: self.__predict(model, input_df)
+        )
 
     @staticmethod
     def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:

--- a/layer/flavors/tensorflow.py
+++ b/layer/flavors/tensorflow.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from typing import Any, Callable, Tuple
+from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
 
-from .base import ModelFlavor
+from .base import ModelFlavor, ModelRuntimeObjects
 
 
 class TensorFlowModelFlavor(ModelFlavor):
@@ -31,13 +31,13 @@ class TensorFlowModelFlavor(ModelFlavor):
             path=directory.as_posix(),
         )
 
-    def load_model_from_directory(
-        self, directory: Path
-    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
+    def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
         import mlflow.tensorflow
 
         model = mlflow.tensorflow.load_model(directory.as_uri())
-        return model, lambda input_df: self.__predict(model, input_df)
+        return ModelRuntimeObjects(
+            model, lambda input_df: self.__predict(model, input_df)
+        )
 
     @staticmethod
     def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:

--- a/layer/flavors/tensorflow.py
+++ b/layer/flavors/tensorflow.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
@@ -40,5 +39,5 @@ class TensorFlowModelFlavor(ModelFlavor):
         )
 
     @staticmethod
-    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+    def __predict(model: ModelObject, input_df: pd.DataFrame) -> pd.DataFrame:
         raise Exception("Not implemented")

--- a/layer/flavors/tensorflow.py
+++ b/layer/flavors/tensorflow.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from typing import Any, Callable, Tuple
 
+import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
@@ -29,7 +31,14 @@ class TensorFlowModelFlavor(ModelFlavor):
             path=directory.as_posix(),
         )
 
-    def load_model_from_directory(self, directory: Path) -> ModelArtifact:
+    def load_model_from_directory(
+        self, directory: Path
+    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
         import mlflow.tensorflow
 
-        return mlflow.tensorflow.load_model(directory.as_uri())
+        model = mlflow.tensorflow.load_model(directory.as_uri())
+        return model, lambda input_df: self.__predict(model, input_df)
+
+    @staticmethod
+    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+        raise Exception("Not implemented")

--- a/layer/flavors/tensorflow.py
+++ b/layer/flavors/tensorflow.py
@@ -4,7 +4,7 @@ from typing import Any
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
-from layer.types import ModelArtifact
+from layer.types import ModelObject
 
 from .base import ModelFlavor, ModelRuntimeObjects
 
@@ -16,7 +16,7 @@ class TensorFlowModelFlavor(ModelFlavor):
     PROTO_FLAVOR = ModelVersion.ModelFlavor.MODEL_FLAVOR_TENSORFLOW
 
     def save_model_to_directory(
-        self, model_object: ModelArtifact, directory: Path
+        self, model_object: ModelObject, directory: Path
     ) -> None:
         import mlflow.tensorflow
         import tensorflow  # type: ignore

--- a/layer/flavors/utils.py
+++ b/layer/flavors/utils.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional
 
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
-from layer.types import ModelArtifact
+from layer.types import ModelObject
 
 from .base import ModelFlavor  # noqa
 from .catboost import CatBoostModelFlavor  # noqa
@@ -40,7 +40,7 @@ PROTO_TO_PYTHON_OBJECT_FLAVORS: Dict[
 ] = {flavor.PROTO_FLAVOR: flavor for flavor in PYTHON_FLAVORS}
 
 
-def get_flavor_for_model(model_object: ModelArtifact) -> Optional[ModelFlavor]:
+def get_flavor_for_model(model_object: ModelObject) -> Optional[ModelFlavor]:
     matching_flavor: Optional[ModelFlavor] = None
     for flavor in PYTHON_FLAVORS:
         if flavor.can_interpret_object(model_object):

--- a/layer/flavors/utils.py
+++ b/layer/flavors/utils.py
@@ -2,7 +2,6 @@ from typing import Dict, List, Optional
 
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
-from layer.flavors.base import ModelFlavor
 from layer.types import ModelArtifact
 
 from .base import ModelFlavor  # noqa

--- a/layer/flavors/xgboost.py
+++ b/layer/flavors/xgboost.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from typing import Any, Callable, Tuple
+from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
 
-from .base import ModelFlavor
+from .base import ModelFlavor, ModelRuntimeObjects
 
 
 class XGBoostModelFlavor(ModelFlavor):
@@ -26,13 +26,13 @@ class XGBoostModelFlavor(ModelFlavor):
 
         mlflow.xgboost.save_model(model_object, path=directory.as_posix())
 
-    def load_model_from_directory(
-        self, directory: Path
-    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
+    def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
         import mlflow.xgboost
 
         model = mlflow.xgboost.load_model(directory.as_uri())
-        return model, lambda input_df: self.__predict(model, input_df)
+        return ModelRuntimeObjects(
+            model, lambda input_df: self.__predict(model, input_df)
+        )
 
     @staticmethod
     def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:

--- a/layer/flavors/xgboost.py
+++ b/layer/flavors/xgboost.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from typing import Any, Callable, Tuple
 
+import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
 from layer.types import ModelArtifact
@@ -24,7 +26,14 @@ class XGBoostModelFlavor(ModelFlavor):
 
         mlflow.xgboost.save_model(model_object, path=directory.as_posix())
 
-    def load_model_from_directory(self, directory: Path) -> ModelArtifact:
+    def load_model_from_directory(
+        self, directory: Path
+    ) -> Tuple[ModelArtifact, Callable[[pd.DataFrame], pd.DataFrame]]:
         import mlflow.xgboost
 
-        return mlflow.xgboost.load_model(directory.as_uri())
+        model = mlflow.xgboost.load_model(directory.as_uri())
+        return model, lambda input_df: self.__predict(model, input_df)
+
+    @staticmethod
+    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+        raise Exception("Not implemented")

--- a/layer/flavors/xgboost.py
+++ b/layer/flavors/xgboost.py
@@ -4,7 +4,7 @@ from typing import Any
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
-from layer.types import ModelArtifact
+from layer.types import ModelObject
 
 from .base import ModelFlavor, ModelRuntimeObjects
 
@@ -20,7 +20,7 @@ class XGBoostModelFlavor(ModelFlavor):
     PROTO_FLAVOR = ModelVersion.ModelFlavor.MODEL_FLAVOR_XGBOOST
 
     def save_model_to_directory(
-        self, model_object: ModelArtifact, directory: Path
+        self, model_object: ModelObject, directory: Path
     ) -> None:
         import mlflow.xgboost
 

--- a/layer/flavors/xgboost.py
+++ b/layer/flavors/xgboost.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 from layerapi.api.entity.model_version_pb2 import ModelVersion
@@ -35,5 +34,5 @@ class XGBoostModelFlavor(ModelFlavor):
         )
 
     @staticmethod
-    def __predict(model: Any, input_df: pd.DataFrame) -> pd.DataFrame:
+    def __predict(model: ModelObject, input_df: pd.DataFrame) -> pd.DataFrame:
         raise Exception("Not implemented")

--- a/layer/main.py
+++ b/layer/main.py
@@ -367,12 +367,13 @@ def _load_model_artifact(
     state: ResourceTransferState,
     no_cache: bool,
 ) -> Model:
-    model_artifact = client.model_catalog.load_model_artifact(
+    model_artifact, predict_func = client.model_catalog.load_model(
         model,
         state=state,
         no_cache=no_cache,
     )
     model.set_artifact(model_artifact)
+    model.set_predict_function(predict_func)
     parameters = client.model_catalog.get_model_train_parameters(
         ModelTrainId(value=str(model.id)),
     )

--- a/layer/main.py
+++ b/layer/main.py
@@ -322,7 +322,7 @@ def get_model(name: str, no_cache: bool = False) -> Model:
         state = ResourceTransferState(model.name)
 
         def callback() -> Model:
-            return _load_model_artifact(client, model, state, no_cache)
+            return _load_model_runtime_objects(client, model, state, no_cache)
 
         if not within_run:
             try:
@@ -361,19 +361,18 @@ def get_model(name: str, no_cache: bool = False) -> Model:
         return model
 
 
-def _load_model_artifact(
+def _load_model_runtime_objects(
     client: LayerClient,
     model: Model,
     state: ResourceTransferState,
     no_cache: bool,
 ) -> Model:
-    model_artifact, predict_func = client.model_catalog.load_model(
+    model_runtime_objects = client.model_catalog.load_model_runtime_objects(
         model,
         state=state,
         no_cache=no_cache,
     )
-    model.set_artifact(model_artifact)
-    model.set_predict_function(predict_func)
+    model.set_model_runtime_objects(model_runtime_objects)
     parameters = client.model_catalog.get_model_train_parameters(
         ModelTrainId(value=str(model.id)),
     )

--- a/layer/training/base_train.py
+++ b/layer/training/base_train.py
@@ -5,7 +5,7 @@ from layer.tracker.project_progress_tracker import RunProgressTracker
 
 
 if TYPE_CHECKING:
-    from layer.types import ModelArtifact
+    from layer.types import ModelObject
 
 
 class BaseTrain:
@@ -97,7 +97,7 @@ class BaseTrain:
 
     def save_model(
         self,
-        trained_model_obj: "ModelArtifact",
+        trained_model_obj: "ModelObject",
         tracker: Optional[RunProgressTracker] = None,
     ) -> Any:
         pass

--- a/layer/training/train.py
+++ b/layer/training/train.py
@@ -11,7 +11,7 @@ from layer.contracts.models import Model
 from layer.exceptions.exceptions import UnexpectedModelTypeException
 from layer.flavors.utils import get_flavor_for_model
 from layer.tracker.project_progress_tracker import RunProgressTracker
-from layer.types import ModelArtifact
+from layer.types import ModelObject
 
 from .base_train import BaseTrain
 
@@ -148,16 +148,16 @@ class Train(BaseTrain):
 
     def save_model(
         self,
-        model_artifact: ModelArtifact,
+        model_object: ModelObject,
         tracker: Optional[RunProgressTracker] = None,
     ) -> Any:
         if not tracker:
             tracker = RunProgressTracker()
         assert self.__train_id
 
-        flavor = get_flavor_for_model(model_artifact)
+        flavor = get_flavor_for_model(model_object)
         if flavor is None:
-            raise UnexpectedModelTypeException(type(model_artifact))
+            raise UnexpectedModelTypeException(type(model_object))
         storage_config = (
             self.__layer_client.model_catalog.get_model_train_storage_configuration(
                 self.__train_id
@@ -170,8 +170,8 @@ class Train(BaseTrain):
             flavor=flavor,
             storage_config=storage_config,
         )
-        self.__layer_client.model_catalog.save_model_artifact(
-            model, model_artifact, tracker=tracker
+        self.__layer_client.model_catalog.save_model_object(
+            model, model_object, tracker=tracker
         )
 
     def __parse_parameter(self, value: str) -> Any:

--- a/layer/types.py
+++ b/layer/types.py
@@ -1,4 +1,4 @@
 from typing import NewType
 
 
-ModelArtifact = NewType("ModelArtifact", object)
+ModelObject = NewType("ModelObject", object)

--- a/test/unit/test_load_model_cache.py
+++ b/test/unit/test_load_model_cache.py
@@ -11,7 +11,7 @@ from layer.config.config import ClientConfig
 from layer.contracts.models import Model
 from layer.contracts.runs import ResourceTransferState
 from layer.flavors.base import ModelFlavor
-from layer.types import ModelArtifact
+from layer.types import ModelObject
 
 
 logger = logging.getLogger(__name__)
@@ -93,9 +93,9 @@ class DummyModelFlavor(ModelFlavor):
         self.model_impl = Mock(name="dummy_model_impl")
 
     def save_model_to_directory(
-        self, model_artifact: ModelArtifact, directory: Path
+        self, model_object: ModelObject, directory: Path
     ) -> None:
         return
 
-    def load_model_from_directory(self, directory: Path) -> ModelArtifact:
+    def load_model_from_directory(self, directory: Path) -> ModelObject:
         return self.model_impl(directory.as_uri())

--- a/test/unit/test_load_model_cache.py
+++ b/test/unit/test_load_model_cache.py
@@ -37,7 +37,7 @@ def test_model_load_from_cache(tmp_path: Path) -> None:
 
     with patch("layer.utils.s3.S3Util.download_dir") as s3_download:
         s3_download.side_effect = download_model_files_from_s3
-        model_catalog.load_model_artifact(model, state=ResourceTransferState())
+        model_catalog.load_model(model, state=ResourceTransferState())
         # assert model was downloaded and not loaded from the cache dir
         s3_download.assert_called_once()
         model_flavor.model_impl.assert_called_once_with(model_cache_dir.as_uri())
@@ -45,7 +45,7 @@ def test_model_load_from_cache(tmp_path: Path) -> None:
     model_flavor.model_impl.reset_mock()
 
     with patch("layer.utils.s3.S3Util.download_dir") as s3_download:
-        model_catalog.load_model_artifact(model, state=ResourceTransferState())
+        model_catalog.load_model(model, state=ResourceTransferState())
         # assert model was loaded from the cache dir without downloading
         s3_download.assert_not_called()
         model_flavor.model_impl.assert_called_once_with(model_cache_dir.as_uri())
@@ -69,9 +69,7 @@ def test_model_load_from_cache_does_not_cache_if_no_cache_true(tmp_path: Path) -
 
     with patch("layer.utils.s3.S3Util.download_dir") as s3_download:
         s3_download.side_effect = download_model_files_from_s3
-        model_catalog.load_model_artifact(
-            model, state=ResourceTransferState(), no_cache=True
-        )
+        model_catalog.load_model(model, state=ResourceTransferState(), no_cache=True)
         model_download_dir = s3_download.call_args[1]["local_dir"]
         # assert model was downloaded and not loaded from the cache dir
         s3_download.assert_called_once()

--- a/test/unit/test_load_model_cache.py
+++ b/test/unit/test_load_model_cache.py
@@ -37,7 +37,7 @@ def test_model_load_from_cache(tmp_path: Path) -> None:
 
     with patch("layer.utils.s3.S3Util.download_dir") as s3_download:
         s3_download.side_effect = download_model_files_from_s3
-        model_catalog.load_model(model, state=ResourceTransferState())
+        model_catalog.load_model_runtime_objects(model, state=ResourceTransferState())
         # assert model was downloaded and not loaded from the cache dir
         s3_download.assert_called_once()
         model_flavor.model_impl.assert_called_once_with(model_cache_dir.as_uri())
@@ -45,7 +45,7 @@ def test_model_load_from_cache(tmp_path: Path) -> None:
     model_flavor.model_impl.reset_mock()
 
     with patch("layer.utils.s3.S3Util.download_dir") as s3_download:
-        model_catalog.load_model(model, state=ResourceTransferState())
+        model_catalog.load_model_runtime_objects(model, state=ResourceTransferState())
         # assert model was loaded from the cache dir without downloading
         s3_download.assert_not_called()
         model_flavor.model_impl.assert_called_once_with(model_cache_dir.as_uri())
@@ -69,7 +69,9 @@ def test_model_load_from_cache_does_not_cache_if_no_cache_true(tmp_path: Path) -
 
     with patch("layer.utils.s3.S3Util.download_dir") as s3_download:
         s3_download.side_effect = download_model_files_from_s3
-        model_catalog.load_model(model, state=ResourceTransferState(), no_cache=True)
+        model_catalog.load_model_runtime_objects(
+            model, state=ResourceTransferState(), no_cache=True
+        )
         model_download_dir = s3_download.call_args[1]["local_dir"]
         # assert model was downloaded and not loaded from the cache dir
         s3_download.assert_called_once()

--- a/test/unit/test_model_flavor.py
+++ b/test/unit/test_model_flavor.py
@@ -170,21 +170,21 @@ class TestModelFlavors:
         tmp_path = tmp_path / "model1"
         model = TFBertForSequenceClassification(BertConfig())
         hf_flavor.save_model_to_directory(model, tmp_path)
-        loaded_model = hf_flavor.load_model_from_directory(tmp_path).model_artifact
+        loaded_model = hf_flavor.load_model_from_directory(tmp_path).model_object
         assert isinstance(loaded_model, TFBertForSequenceClassification)
 
         # Bert Pytorch Model
         tmp_path = tmp_path / "model2"
         model = BertForSequenceClassification(BertConfig())
         hf_flavor.save_model_to_directory(model, tmp_path)
-        loaded_model = hf_flavor.load_model_from_directory(tmp_path).model_artifact
+        loaded_model = hf_flavor.load_model_from_directory(tmp_path).model_object
         assert isinstance(loaded_model, BertForSequenceClassification)
 
         # GPT2 LMHEad Tensorflow Model
         tmp_path = tmp_path / "model3"
         model = TFGPT2LMHeadModel(GPT2Config())
         hf_flavor.save_model_to_directory(model, tmp_path)
-        loaded_model = hf_flavor.load_model_from_directory(tmp_path).model_artifact
+        loaded_model = hf_flavor.load_model_from_directory(tmp_path).model_object
 
         assert isinstance(loaded_model, TFGPT2LMHeadModel)
 
@@ -202,7 +202,7 @@ class TestModelFlavors:
         pt_flavor = PyTorchModelFlavor()
         pt_model = torch.nn.Sequential()
         pt_flavor.save_model_to_directory(pt_model, tmp_path)
-        loaded_model = pt_flavor.load_model_from_directory(tmp_path).model_artifact
+        loaded_model = pt_flavor.load_model_from_directory(tmp_path).model_object
         assert isinstance(loaded_model, torch.nn.Module)
 
     def test_yolo_save_load(self, tmp_path):
@@ -233,7 +233,7 @@ class TestModelFlavors:
             del sys.modules["yolov5"]
 
         # Load and check the type of the model
-        model = pt_flavor.load_model_from_directory(tmp_path).model_artifact
+        model = pt_flavor.load_model_from_directory(tmp_path).model_object
         assert model.__class__.__name__ == "AutoShape"
 
     def test_custom_flavor(self, tmp_path):

--- a/test/unit/test_model_flavor.py
+++ b/test/unit/test_model_flavor.py
@@ -170,21 +170,21 @@ class TestModelFlavors:
         tmp_path = tmp_path / "model1"
         model = TFBertForSequenceClassification(BertConfig())
         hf_flavor.save_model_to_directory(model, tmp_path)
-        loaded_model, _ = hf_flavor.load_model_from_directory(tmp_path)
+        loaded_model = hf_flavor.load_model_from_directory(tmp_path).model_artifact
         assert isinstance(loaded_model, TFBertForSequenceClassification)
 
         # Bert Pytorch Model
         tmp_path = tmp_path / "model2"
         model = BertForSequenceClassification(BertConfig())
         hf_flavor.save_model_to_directory(model, tmp_path)
-        loaded_model, _ = hf_flavor.load_model_from_directory(tmp_path)
+        loaded_model = hf_flavor.load_model_from_directory(tmp_path).model_artifact
         assert isinstance(loaded_model, BertForSequenceClassification)
 
         # GPT2 LMHEad Tensorflow Model
         tmp_path = tmp_path / "model3"
         model = TFGPT2LMHeadModel(GPT2Config())
         hf_flavor.save_model_to_directory(model, tmp_path)
-        loaded_model, _ = hf_flavor.load_model_from_directory(tmp_path)
+        loaded_model = hf_flavor.load_model_from_directory(tmp_path).model_artifact
 
         assert isinstance(loaded_model, TFGPT2LMHeadModel)
 
@@ -202,7 +202,7 @@ class TestModelFlavors:
         pt_flavor = PyTorchModelFlavor()
         pt_model = torch.nn.Sequential()
         pt_flavor.save_model_to_directory(pt_model, tmp_path)
-        loaded_model, _ = pt_flavor.load_model_from_directory(tmp_path)
+        loaded_model = pt_flavor.load_model_from_directory(tmp_path).model_artifact
         assert isinstance(loaded_model, torch.nn.Module)
 
     def test_yolo_save_load(self, tmp_path):
@@ -233,7 +233,7 @@ class TestModelFlavors:
             del sys.modules["yolov5"]
 
         # Load and check the type of the model
-        model, _ = pt_flavor.load_model_from_directory(tmp_path)
+        model = pt_flavor.load_model_from_directory(tmp_path).model_artifact
         assert model.__class__.__name__ == "AutoShape"
 
     def test_custom_flavor(self, tmp_path):

--- a/test/unit/test_model_flavor.py
+++ b/test/unit/test_model_flavor.py
@@ -170,21 +170,21 @@ class TestModelFlavors:
         tmp_path = tmp_path / "model1"
         model = TFBertForSequenceClassification(BertConfig())
         hf_flavor.save_model_to_directory(model, tmp_path)
-        loaded_model = hf_flavor.load_model_from_directory(tmp_path)
+        loaded_model, _ = hf_flavor.load_model_from_directory(tmp_path)
         assert isinstance(loaded_model, TFBertForSequenceClassification)
 
         # Bert Pytorch Model
         tmp_path = tmp_path / "model2"
         model = BertForSequenceClassification(BertConfig())
         hf_flavor.save_model_to_directory(model, tmp_path)
-        loaded_model = hf_flavor.load_model_from_directory(tmp_path)
+        loaded_model, _ = hf_flavor.load_model_from_directory(tmp_path)
         assert isinstance(loaded_model, BertForSequenceClassification)
 
         # GPT2 LMHEad Tensorflow Model
         tmp_path = tmp_path / "model3"
         model = TFGPT2LMHeadModel(GPT2Config())
         hf_flavor.save_model_to_directory(model, tmp_path)
-        loaded_model = hf_flavor.load_model_from_directory(tmp_path)
+        loaded_model, _ = hf_flavor.load_model_from_directory(tmp_path)
 
         assert isinstance(loaded_model, TFGPT2LMHeadModel)
 
@@ -202,7 +202,7 @@ class TestModelFlavors:
         pt_flavor = PyTorchModelFlavor()
         pt_model = torch.nn.Sequential()
         pt_flavor.save_model_to_directory(pt_model, tmp_path)
-        loaded_model = pt_flavor.load_model_from_directory(tmp_path)
+        loaded_model, _ = pt_flavor.load_model_from_directory(tmp_path)
         assert isinstance(loaded_model, torch.nn.Module)
 
     def test_yolo_save_load(self, tmp_path):
@@ -233,7 +233,7 @@ class TestModelFlavors:
             del sys.modules["yolov5"]
 
         # Load and check the type of the model
-        model = pt_flavor.load_model_from_directory(tmp_path)
+        model, _ = pt_flavor.load_model_from_directory(tmp_path)
         assert model.__class__.__name__ == "AutoShape"
 
     def test_custom_flavor(self, tmp_path):

--- a/test/unit/test_model_flavor.py
+++ b/test/unit/test_model_flavor.py
@@ -259,7 +259,7 @@ class TestModelFlavors:
         assert type(flavor).__name__ == CustomModelFlavor.__name__
 
         flavor.save_model_to_directory(model, tmp_path)
-        loaded_model = flavor.load_model_from_directory(tmp_path)
+        loaded_model = flavor.load_model_from_directory(tmp_path).model_object
         assert isinstance(loaded_model, layer.CustomModel)
         assert isinstance(loaded_model.model, SVC)
 


### PR DESCRIPTION
Introduce a `Model.predict(input_df: pandas.Dataframe) -> pandas.Dataframe` API.
Implemented for sci-kit learn and catboost models.