### PR TITLE
Fix pandas describe for Images and Arrays 

### DIFF
--- a/layer/pandas_extensions.py
+++ b/layer/pandas_extensions.py
@@ -320,6 +320,17 @@ class Arrays(ExtensionArray):
             total_bytes += arr.nbytes
         return total_bytes
 
+    def value_counts(
+        values: Sequence[Any],
+        sort: bool = True,
+        ascending: bool = False,
+        normalize: bool = False,
+        bins: Any = None,
+        dropna: bool = True,
+    ) -> pd.Series:  # type: ignore
+        # make all values unique for now
+        return pd.Series(np.ones(len(values), dtype=np.int64))
+
 
 def _array_bytes(arr: np.ndarray) -> bytes:  # type: ignore
     with io.BytesIO() as buf:

--- a/layer/pandas_extensions.py
+++ b/layer/pandas_extensions.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 from pandas._typing import PositionalIndexer  # type: ignore
 from pandas.core.arrays.base import ExtensionArray  # type: ignore
@@ -164,7 +165,9 @@ class Images(ExtensionArray):
         if not isinstance(other, Images):
             return eq_arr
         for i in range(min(len(self), len(other))):
-            if _image_bytes(self._images[i]) == _image_bytes(other._images[i]):
+            if np.array_equal(
+                np.asarray(self._images[i]), np.asarray(other._images[i])
+            ):
                 eq_arr[i] = True
         return eq_arr
 
@@ -179,6 +182,17 @@ class Images(ExtensionArray):
         for buf in self._images_byte_arr():
             total_bytes += len(buf)
         return total_bytes
+
+    def value_counts(
+        values: Sequence[Any],
+        sort: bool = True,
+        ascending: bool = False,
+        normalize: bool = False,
+        bins: Any = None,
+        dropna: bool = True,
+    ) -> pd.Series:  # type: ignore
+        # make all values unique for now
+        return pd.Series(np.ones(len(values), dtype=np.int64))
 
 
 def _image_bytes(image: "Image") -> bytes:

--- a/layer/pandas_extensions.py
+++ b/layer/pandas_extensions.py
@@ -107,12 +107,12 @@ class Images(ExtensionArray):
         *,
         dtype: Optional[ExtensionDtype] = None,
         copy: bool = False,
-    ) -> "Images":
-        return Images(scalars)
+    ) -> Any:
+        return cls(scalars)
 
     @classmethod
-    def _concat_same_type(cls, to_concat: Sequence["Images"]) -> "Images":
-        return Images(tuple(itertools.chain(*to_concat)))
+    def _concat_same_type(cls, to_concat: Sequence["Images"]) -> Any:
+        return cls(tuple(itertools.chain(*to_concat)))
 
     @property
     def dtype(self) -> ExtensionDtype:
@@ -122,7 +122,7 @@ class Images(ExtensionArray):
         return Images(tuple(image.copy() for image in self._images))
 
     def isna(self) -> np.ndarray:  # type: ignore
-        return np.array([image is not None for image in self._images], dtype=bool)
+        return np.array([image is None for image in self._images], dtype=bool)
 
     def __len__(self) -> int:
         return len(self._images)
@@ -265,7 +265,7 @@ class Arrays(ExtensionArray):
         return Arrays(tuple(arr.copy() for arr in self._arrays))
 
     def isna(self) -> np.ndarray:  # type: ignore
-        return np.array([arr is not None for arr in self._arrays], dtype=bool)
+        return np.array([arr is None for arr in self._arrays], dtype=bool)
 
     def __len__(self) -> int:
         return len(self._arrays)

--- a/test/unit/test_pandas_extensions.py
+++ b/test/unit/test_pandas_extensions.py
@@ -6,7 +6,6 @@ import pandas as pd
 import PIL
 import pytest
 from pandas.testing import assert_frame_equal
-from PIL import ImageDraw
 from PIL.Image import Image
 
 import layer
@@ -17,14 +16,20 @@ _PARQUET_ENGINE = "pyarrow"
 
 
 def test_pandas_images_read_write(tmp_path):
-    data = _image_data_frame(num_images=32)
+    data = _image_data_frame(num_images=3)
 
     parquet_path = tmp_path / str(uuid4())
 
     data.to_parquet(parquet_path, engine=_PARQUET_ENGINE)
     data_parquet = pd.read_parquet(parquet_path, engine=_PARQUET_ENGINE)
 
-    assert_frame_equal(data, data_parquet)
+    def to_numpy(d):
+        return np.array([np.asarray(image) for image in d["image"]])
+
+    # Cannot use assert_frame_equal, because of the incorrect comparison of boolean arrays in
+    # https://github.com/pandas-dev/pandas/blob/ad190575aa75962d2d0eade2de81a5fe5a2e285b/pandas/_libs/testing.pyx#L177
+    # due to ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
+    np.testing.assert_array_equal(to_numpy(data), to_numpy(data_parquet))
     assert data_parquet["image"].dtype.name == "layer.image"
 
 
@@ -58,7 +63,7 @@ def test_pandas_images_head():
     ],
 )
 def test_pandas_images_reduce(reduce_func, result):
-    images = layer.Images([_generate_image(n) for n in range(0, 3)])
+    images = layer.Images([_image(n) for n in range(0, 3)])
     assert images._reduce(reduce_func) == result  # pylint: disable=protected-access
 
 
@@ -68,7 +73,7 @@ def test_pandas_images_info():
         data.info(buf=buf)
         info_str = buf.getvalue()
         # assert total bytes for each image is computed correctly
-        assert "memory usage: 14.1 KB" in info_str, f"actual: {info_str}"
+        assert "memory usage: 3.0 KB" in info_str, f"actual: {info_str}"
 
 
 def test_seaborn_plot():
@@ -81,8 +86,8 @@ def test_seaborn_plot():
 
 
 def test_pandas_images_eq_types_do_not_match():
-    image0 = _generate_image(0)
-    image1 = _generate_image(1)
+    image0 = _image(0)
+    image1 = _image(1)
     comp = Images(
         (
             image0,
@@ -93,10 +98,10 @@ def test_pandas_images_eq_types_do_not_match():
 
 
 def test_pandas_images_eq_equals():
-    image0 = _generate_image(0)
-    image1 = _generate_image(1)
-    image2 = _generate_image(0)
-    image3 = _generate_image(1)
+    image0 = _image(0)
+    image1 = _image(1)
+    image2 = _image(0)
+    image3 = _image(1)
 
     comp = Images((image0, image1,)).__eq__(
         Images(
@@ -110,10 +115,10 @@ def test_pandas_images_eq_equals():
 
 
 def test_pandas_images_eq_does_not_match():
-    image0 = _generate_image(0)
-    image1 = _generate_image(1)
-    image2 = _generate_image(0)
-    image3 = _generate_image(2)
+    image0 = _image(0)
+    image1 = _image(1)
+    image2 = _image(0)
+    image3 = _image(2)
     comp = Images((image0, image1,)).__eq__(
         Images(
             (
@@ -126,9 +131,9 @@ def test_pandas_images_eq_does_not_match():
 
 
 def test_pandas_images_eq_length_do_not_match_other():
-    image0 = _generate_image(0)
-    image1 = _generate_image(1)
-    image2 = _generate_image(0)
+    image0 = _image(0)
+    image1 = _image(1)
+    image2 = _image(0)
     comp = Images(
         (
             image0,
@@ -139,9 +144,9 @@ def test_pandas_images_eq_length_do_not_match_other():
 
 
 def test_pandas_images_eq_length_do_not_match_self():
-    image0 = _generate_image(0)
-    image1 = _generate_image(0)
-    image2 = _generate_image(1)
+    image0 = _image(0)
+    image1 = _image(0)
+    image2 = _image(1)
     comp = Images((image0,)).__eq__(
         Images(
             (
@@ -154,9 +159,9 @@ def test_pandas_images_eq_length_do_not_match_self():
 
 
 def test_pandas_images_concat_same_type():
-    image0 = _generate_image(0)
-    image1 = _generate_image(1)
-    image2 = _generate_image(2)
+    image0 = _image(0)
+    image1 = _image(1)
+    image2 = _image(2)
 
     images = Images._concat_same_type(  # pylint: disable=protected-access
         [
@@ -190,16 +195,11 @@ def test_pandas_images_construct_from_string_raises_type_error_for_other_types()
 
 
 def _image_data_frame(num_images: int) -> pd.DataFrame:
-    return pd.DataFrame(
-        {"image": layer.Images([_generate_image(n) for n in range(num_images)])}
-    )
+    return pd.DataFrame({"image": layer.Images([_image(n) for n in range(num_images)])})
 
 
-def _generate_image(n: int) -> Image:
-    image = PIL.Image.new("RGB", (160, 40), color=(73, 109, 137))
-    draw = ImageDraw.Draw(image)
-    draw.text((11, 10), f"Test #{n}", fill=(255, 255, 0))
-    return image
+def _image(n: int) -> Image:
+    return PIL.Image.new("RGB", (1, 1), color=(73, 109, n))
 
 
 def test_pandas_arrays_read_write(tmp_path):

--- a/test/unit/test_pandas_extensions.py
+++ b/test/unit/test_pandas_extensions.py
@@ -260,3 +260,11 @@ def test_pandas_images_describe():
         {"image": [3, 3, 0, 1]}, index=["count", "unique", "top", "freq"]
     )
     assert_frame_equal(describe, data.describe())
+
+
+def test_pandas_arrays_describe():
+    data = _array_data_frame()
+    describe = pd.DataFrame(
+        {"array": [3, 3, 0, 1]}, index=["count", "unique", "top", "freq"]
+    )
+    assert_frame_equal(describe, data.describe())

--- a/test/unit/test_pandas_extensions.py
+++ b/test/unit/test_pandas_extensions.py
@@ -252,3 +252,11 @@ def _array_data_frame() -> pd.DataFrame:
             )
         }
     )
+
+
+def test_pandas_images_describe():
+    data = _image_data_frame(num_images=3)
+    describe = pd.DataFrame(
+        {"image": [3, 3, 0, 1]}, index=["count", "unique", "top", "freq"]
+    )
+    assert_frame_equal(describe, data.describe())


### PR DESCRIPTION
Fix pandas describe crashing if `layer.Images` or `layer.Arrays` types are used.

Unique values for `layer.Images` and `layer.Arrays` are not counted for now, and always returns all values unique.