### PR TITLE
Implicitly convert images and ndarrays

### DIFF
--- a/layer/clients/data_catalog.py
+++ b/layer/clients/data_catalog.py
@@ -58,6 +58,7 @@ from layer.contracts.datasets import (
 )
 from layer.contracts.runs import DatasetFunctionDefinition
 from layer.exceptions.exceptions import LayerClientException
+from layer.pandas_extensions import _infer_custom_types
 from layer.utils.file_utils import tar_directory
 from layer.utils.grpc import create_grpc_channel, generate_client_error_from_grpc_error
 from layer.utils.s3 import S3Util
@@ -168,7 +169,9 @@ class DataCatalogClient:
         """
 
         # Creates a Record batch from the pandas dataframe
-        batch = pyarrow.RecordBatch.from_pandas(data, preserve_index=False)
+        batch = pyarrow.RecordBatch.from_pandas(
+            _infer_custom_types(data), preserve_index=False
+        )
         try:
             writer, _ = self._get_dataset_writer(name, build_id, batch.schema)
             try:

--- a/layer/pandas_extensions.py
+++ b/layer/pandas_extensions.py
@@ -346,3 +346,21 @@ def _register_type_extensions() -> None:
     # register pandas extension types
     register_extension_dtype(_ImageDtype)
     register_extension_dtype(_ArrayDtype)
+
+
+def _infer_custom_types(data: pd.DataFrame) -> pd.DataFrame:
+    if len(data) == 0:
+        return data
+    first_row = data.head(n=1)
+    try:
+        from PIL.Image import Image
+
+        for col in first_row:
+            value = data[col][0]
+            if isinstance(value, Image):
+                data[col] = Images(data[col])
+            elif isinstance(value, np.ndarray) and value.ndim > 1:
+                data[col] = Arrays(data[col])
+    except ImportError:
+        pass
+    return data

--- a/test/unit/test_pandas_extensions.py
+++ b/test/unit/test_pandas_extensions.py
@@ -298,6 +298,7 @@ def test_infer_custom_types_infers_images_type(tmp_path):
     data_parquet = pd.read_parquet(parquet_path, engine=_PARQUET_ENGINE)
 
     assert inferred["img"].dtype.name == "layer.image"
+    # assert implictly converted types was written and read correctly
     _assert_image_columns_equal(data, data_parquet, col="img")
 
 
@@ -311,6 +312,7 @@ def test_infer_custom_types_infers_arrays_type(tmp_path):
     data_parquet = pd.read_parquet(parquet_path, engine=_PARQUET_ENGINE)
 
     assert inferred["arr"].dtype.name == "layer.ndarray"
+    # assert implictly converted types was written and read correctly
     assert_frame_equal(data, data_parquet)
 
 
@@ -322,4 +324,5 @@ def test_infer_custom_types_does_not_infer_for_1dim_array(tmp_path):
     data_parquet = pd.read_parquet(parquet_path, engine=_PARQUET_ENGINE)
 
     assert inferred["arr"].dtype.name == "object"
+    # assert implictly converted types was written and read correctly
     assert_frame_equal(data, data_parquet)


### PR DESCRIPTION
With this change, there is no need to wrap pandas data frame image or ndarray columns into `layer.Images` or `layer.Arrays`. Instead, `store_dataset` will figure this out by checking if the instances are `PIL.Image.Image` and `numpy.ndarray` and do the conversion automatically.