### PR TITLE
Skip segfaulting tests only on Mac M1

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,10 +1,15 @@
+import platform
+
+
+def _is_darwin():
+    return (platform.system() == "Darwin",)
+
+
 def _is_darwin_arm64():
-    import platform
-
-    # on M1 Mac platforms the result should be
+    # on M1 Mac platforms platform.version() returns
     # 'Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:29 PDT 2022; root:xnu-8020.121.3~4/RELEASE_ARM64_T8101'
-    platform_version = platform.version()
-    return "Darwin" in platform_version and "ARM64" in platform_version
+    return _is_darwin() and ("ARM64" in platform.version())
 
 
+IS_DARWIN = _is_darwin()
 IS_DARWIN_ARM64 = _is_darwin_arm64()

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,10 @@
+def _is_darwin_arm64():
+    import platform
+
+    # on M1 Mac platforms the result should be
+    # 'Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:29 PDT 2022; root:xnu-8020.121.3~4/RELEASE_ARM64_T8101'
+    platform_version = platform.version()
+    return "Darwin" in platform_version and "ARM64" in platform_version
+
+
+IS_DARWIN_ARM64 = _is_darwin_arm64()

--- a/test/unit/test_model_flavor.py
+++ b/test/unit/test_model_flavor.py
@@ -1,6 +1,5 @@
 # type: ignore
 import logging
-import platform
 from pathlib import Path
 
 import pytest
@@ -19,11 +18,13 @@ from layer.flavors import (
 )
 from layer.flavors.utils import get_flavor_for_model
 
+from .. import IS_DARWIN_ARM64
+
 
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipif(platform.system() == "Darwin", reason="Segfaults on Mac")
+@pytest.mark.skipif(IS_DARWIN_ARM64, reason="Segfaults on Mac M1")
 class TestModelFlavors:
     def test_lightgbm_flavor(self):
         import lightgbm as lgb

--- a/test/unit/test_train.py
+++ b/test/unit/test_train.py
@@ -11,7 +11,7 @@ from layer.config import ClientConfig
 from layer.exceptions.exceptions import UnexpectedModelTypeException
 from layer.training.train import Train
 
-from .. import IS_DARWIN_ARM64
+from .. import IS_DARWIN
 
 
 logger = logging.getLogger(__name__)
@@ -109,7 +109,7 @@ def test_train_raises_exception_if_error_happens() -> None:
         set(),
     ],
 )
-@pytest.mark.skipif(IS_DARWIN_ARM64, reason="Segfaults on Mac M1")
+@pytest.mark.skipif(IS_DARWIN, reason="Segfaults on Mac")
 def test_when_save_model_gets_invalid_object_then_throw_exception(
     invalid_model_object: Any,
 ) -> None:

--- a/test/unit/test_train.py
+++ b/test/unit/test_train.py
@@ -1,5 +1,4 @@
 import logging
-import platform
 import uuid
 from typing import Any
 from unittest.mock import MagicMock, create_autospec
@@ -11,6 +10,8 @@ from layer.clients.model_catalog import ModelCatalogClient
 from layer.config import ClientConfig
 from layer.exceptions.exceptions import UnexpectedModelTypeException
 from layer.training.train import Train
+
+from .. import IS_DARWIN_ARM64
 
 
 logger = logging.getLogger(__name__)
@@ -108,7 +109,7 @@ def test_train_raises_exception_if_error_happens() -> None:
         set(),
     ],
 )
-@pytest.mark.skipif(platform.system() == "Darwin", reason="Segfaults on Mac")
+@pytest.mark.skipif(IS_DARWIN_ARM64, reason="Segfaults on Mac M1")
 def test_when_save_model_gets_invalid_object_then_throw_exception(
     invalid_model_object: Any,
 ) -> None:


### PR DESCRIPTION
Skip segfaulting tests only on Mac M1. Related to suggestion in https://github.com/layerai/sdk/pull/62#discussion_r883413545.

Doing a substring check, as other methods still return i386 when run through `Rosetta` emulation.