### PR TITLE
Ignore line that is only sometimes covered by the tests

### DIFF
--- a/layer/projects/execution_planner.py
+++ b/layer/projects/execution_planner.py
@@ -207,7 +207,9 @@ def _stringify_entity_cycle(entity_cycle_path: List[AssetPath]) -> str:
     def rotate_list(entity_cycle_path: List[str]) -> List[str]:
         smallest_idx = 0
         for i in range(1, len(entity_cycle_path)):
-            if entity_cycle_path[i] < entity_cycle_path[smallest_idx]:
+            if (
+                entity_cycle_path[i] < entity_cycle_path[smallest_idx]
+            ):  # pragma: no cover
                 smallest_idx = i
         rotated = deque(entity_cycle_path)
         rotated.rotate(-smallest_idx)


### PR DESCRIPTION
In `test_build_graph_fails_if_project_contains_cycle` we create some mock entities. Based on their structure we might end up covering or not covering the special case in `_stringify_entity_cycle`.

Ignore it to avoid confusing diffs in coverage