### PR TITLE
Support GIF for layer.log

### DIFF
--- a/layer/logged_data/log_data_runner.py
+++ b/layer/logged_data/log_data_runner.py
@@ -63,9 +63,9 @@ class LogDataRunner:
                     self._log_number(tag=tag, number=value)
             elif isinstance(value, pd.DataFrame):
                 self._log_dataframe(tag=tag, df=value)
-            elif isinstance(value, Path) and LogDataRunner._has_allowed_extension(
-                value, [".gif", ".png", ".jpg", ".jpeg"]
-            ):
+            elif LogDataRunner._is_image(value):
+                if TYPE_CHECKING:
+                    assert isinstance(value, Path)
                 self._log_image_from_path(tag=tag, path=value)
             elif self._is_pil_image(value):
                 if TYPE_CHECKING:
@@ -200,6 +200,12 @@ class LogDataRunner:
             if extension == allowed_extension:
                 return True
         return False
+
+    @staticmethod
+    def _is_image(value: Any) -> bool:
+        return isinstance(value, Path) and LogDataRunner._has_allowed_extension(
+            value, [".gif", ".png", ".jpg", ".jpeg"]
+        )
 
     def _is_pil_image(self, value: Any) -> bool:
         return "PIL.Image" in self._get_base_module_list(value)

--- a/layer/logged_data/log_data_runner.py
+++ b/layer/logged_data/log_data_runner.py
@@ -63,7 +63,9 @@ class LogDataRunner:
                     self._log_number(tag=tag, number=value)
             elif isinstance(value, pd.DataFrame):
                 self._log_dataframe(tag=tag, df=value)
-            elif isinstance(value, Path):
+            elif isinstance(value, Path) and LogDataRunner._has_allowed_extension(
+                value, [".gif", ".png", ".jpg", ".jpeg"]
+            ):
                 self._log_image_from_path(tag=tag, path=value)
             elif self._is_pil_image(value):
                 if TYPE_CHECKING:
@@ -186,6 +188,18 @@ class LogDataRunner:
             self._log_plot_figure(tag, plt.gcf())
         else:
             raise ValueError("No figures in the current pyplot state!")
+
+    @staticmethod
+    def _has_allowed_extension(
+        file: Path, allowed_extensions: Optional[List[str]]
+    ) -> bool:
+        if allowed_extensions is None:
+            allowed_extensions = []
+        extension = file.suffix.lower()
+        for allowed_extension in allowed_extensions:
+            if extension == allowed_extension:
+                return True
+        return False
 
     def _is_pil_image(self, value: Any) -> bool:
         return "PIL.Image" in self._get_base_module_list(value)

--- a/test/unit/logged_data/test_log_data_runner.py
+++ b/test/unit/logged_data/test_log_data_runner.py
@@ -394,3 +394,32 @@ def test_given_runner_when_log_image_by_path_then_calls_log_binary(
         train_id=train_id, tag=tag, dataset_build_id=dataset_build_id
     )
     mock_put.assert_called_with("http://path/for/upload", data=ANY)
+
+
+@pytest.mark.parametrize(
+    ("train_id", "dataset_build_id"), [(uuid.uuid4(), None), (None, uuid.uuid4())]
+)
+def test_given_runner_when_log_image_by_path_with_unsupported_extension_then_raise(
+    tmpdir, train_id: Optional[UUID], dataset_build_id: Optional[UUID]
+) -> None:
+    # given
+    logged_data_client = MagicMock(spec=LoggedDataClient)
+    client = MagicMock(
+        set_spec=LayerClient,
+        logged_data_service_client=logged_data_client,
+    )
+    runner = LogDataRunner(
+        client=client, train_id=train_id, logger=None, dataset_build_id=dataset_build_id
+    )
+    tag = "image-by-path"
+    image_data = np.random.rand(100, 100, 3) * 255
+    image = PIL.Image.fromarray(image_data.astype("uint8")).convert("RGBA")
+    path = tmpdir.join("image.webp")
+    image.save(str(path))
+
+    # when
+    with pytest.raises(ValueError, match=r".*Unsupported value type ->.*"):
+        runner.log({tag: Path(str(path))})
+
+    # then
+    logged_data_client.log_binary_data.assert_not_called()


### PR DESCRIPTION
LAY-3207

Previously, we allows any `Path` to be saved directly to S3. With this change, we explicitly check for the file extension. This will be even more necessary when we add video support to differentiate between different `Path` objects.