### PR TITLE
Fix custom model pickling

### DIFF
--- a/layer/flavors/custom.py
+++ b/layer/flavors/custom.py
@@ -1,9 +1,8 @@
-import pickle
+import pickle  # nosec
 from abc import abstractmethod
 from pathlib import Path
 from typing import Any
 
-import cloudpickle  # type: ignore
 import pandas
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
@@ -50,7 +49,7 @@ class CustomModelFlavor(ModelFlavor):
 
     def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
         with open(directory / self.MODEL_PICKLE_FILE, mode="rb") as file:
-            model = pickle.load(file)
+            model = pickle.load(file)  # nosec
             return ModelRuntimeObjects(
                 model, lambda input_df: self.__predict(model, input_df)
             )

--- a/test/unit/common/dummy_model.py
+++ b/test/unit/common/dummy_model.py
@@ -1,0 +1,17 @@
+from layer import CustomModel
+
+
+class DummyModel(CustomModel):
+    def __init__(self):
+        super().__init__()
+
+        from sklearn.datasets import load_iris
+        from sklearn.svm import SVC
+
+        svc = SVC()
+        x, y = load_iris(return_X_y=True)
+        svc.fit(x, y)
+        self.model = svc
+
+    def predict(self, model_input):
+        return self.model.predict(model_input)

--- a/test/unit/test_model_flavor.py
+++ b/test/unit/test_model_flavor.py
@@ -248,25 +248,13 @@ class TestModelFlavors:
         from sklearn.datasets import load_iris
         from sklearn.svm import SVC
 
-        from layer import CustomModel
-
-        class DummyModel(CustomModel):
-            def __init__(self):
-                super().__init__()
-                svc = SVC()
-                svc.set_params(kernel="linear")
-                x, y = load_iris(return_X_y=True)
-                svc.fit(x, y)
-                self.model = svc
-
-            def predict(self, model_input):
-                return self.model.predict(model_input)
+        from .common.dummy_model import DummyModel
 
         model = DummyModel()
         flavor = get_flavor_for_model(model)
         assert type(flavor).__name__ == CustomModelFlavor.__name__
 
-        flavor.save_model_to_directory(DummyModel(), tmp_path)
+        flavor.save_model_to_directory(model, tmp_path)
         loaded_model = flavor.load_model_from_directory(tmp_path).model_object
         assert isinstance(loaded_model, layer.CustomModel)
         assert isinstance(loaded_model.model, SVC)


### PR DESCRIPTION
Cloudpickle requires same python versions to pickle and load models. Whereas pickle has backward compatibility.
