### PR TITLE
Fix custom model pickling

### DIFF
--- a/layer/flavors/custom.py
+++ b/layer/flavors/custom.py
@@ -105,7 +105,9 @@ class CustomModelFlavor(ModelFlavor):
             spec.loader.exec_module(module)  # type: ignore
             sys.modules[model_module_name] = module
         except Exception:
-            raise Exception("Failed to load model. Please clear your cache with `layer.clear_cache` and try again!")
+            raise Exception(
+                "Failed to load model. Please clear your cache with `layer.clear_cache` and try again!"
+            )
 
         # Load model itself
         with open(directory / self.MODEL_PICKLE_FILE, mode="rb") as file:

--- a/layer/flavors/custom.py
+++ b/layer/flavors/custom.py
@@ -1,3 +1,4 @@
+import pickle
 from abc import abstractmethod
 from pathlib import Path
 from typing import Any
@@ -45,7 +46,7 @@ class CustomModelFlavor(ModelFlavor):
     ) -> None:
         directory.mkdir(parents=True, exist_ok=True)
         with open(directory / self.MODEL_PICKLE_FILE, mode="wb") as file:
-            cloudpickle.dump(model_object, file)
+            cloudpickle.dump(model_object, file, protocol=pickle.DEFAULT_PROTOCOL)
 
     def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
         with open(directory / self.MODEL_PICKLE_FILE, mode="rb") as file:

--- a/layer/flavors/custom.py
+++ b/layer/flavors/custom.py
@@ -50,15 +50,21 @@ class CustomModelFlavor(ModelFlavor):
         # Store class config
         with open(directory / self.MODEL_CONFIG_FILE, mode="w") as file:
             custom_model_class = type(model_object)
-            class_config = custom_model_class.__module__ + "." + custom_model_class.__name__
+            class_config = (
+                custom_model_class.__module__ + "." + custom_model_class.__name__
+            )
             file.write(class_config)
 
         # Store class definition
         import inspect
+
         custom_class_model = type(model_object)
         class_model_source_code = inspect.getsource(custom_class_model)
         with open(directory / self.MODEL_SOURCE_FILE, mode="w") as file:
-            class_model_source_code = "import layer\nfrom layer import CustomModel\n\n" + class_model_source_code
+            class_model_source_code = (
+                "import layer\nfrom layer import CustomModel\n\n"
+                + class_model_source_code
+            )
             file.write(class_model_source_code)
 
         # Store model itself
@@ -75,7 +81,10 @@ class CustomModelFlavor(ModelFlavor):
         # Load and register custom class definition
         import importlib.util
         import sys
-        spec = importlib.util.spec_from_file_location(model_name, directory / self.MODEL_SOURCE_FILE)
+
+        spec = importlib.util.spec_from_file_location(
+            model_name, directory / self.MODEL_SOURCE_FILE
+        )
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         sys.modules[model_module_name] = module

--- a/layer/flavors/custom.py
+++ b/layer/flavors/custom.py
@@ -36,6 +36,8 @@ class CustomModelFlavor(ModelFlavor):
 
     MODULE_KEYWORD = "layer"
     MODEL_PICKLE_FILE = "custom_model.pkl"
+    MODEL_SOURCE_FILE = "custom_model.py"
+    MODEL_CONFIG_FILE = "custom_model.config"
     PROTO_FLAVOR = ModelVersion.ModelFlavor.MODEL_FLAVOR_CUSTOM
 
     def save_model_to_directory(
@@ -44,10 +46,41 @@ class CustomModelFlavor(ModelFlavor):
         directory: Path,
     ) -> None:
         directory.mkdir(parents=True, exist_ok=True)
+
+        # Store class config
+        with open(directory / self.MODEL_CONFIG_FILE, mode="w") as file:
+            custom_model_class = type(model_object)
+            class_config = custom_model_class.__module__ + "." + custom_model_class.__name__
+            file.write(class_config)
+
+        # Store class definition
+        import inspect
+        custom_class_model = type(model_object)
+        class_model_source_code = inspect.getsource(custom_class_model)
+        with open(directory / self.MODEL_SOURCE_FILE, mode="w") as file:
+            class_model_source_code = "import layer\nfrom layer import CustomModel\n\n" + class_model_source_code
+            file.write(class_model_source_code)
+
+        # Store model itself
         with open(directory / self.MODEL_PICKLE_FILE, mode="wb") as file:
             pickle.dump(model_object, file, protocol=pickle.DEFAULT_PROTOCOL)
 
     def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
+        # Load model config
+        with open(directory / self.MODEL_CONFIG_FILE, mode="r") as file:
+            model_config = file.readline()
+            model_name = model_config.split(".")[-1]
+            model_module_name = ".".join(model_config.split(".")[:-1])
+
+        # Load and register custom class definition
+        import importlib.util
+        import sys
+        spec = importlib.util.spec_from_file_location(model_name, directory / self.MODEL_SOURCE_FILE)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        sys.modules[model_module_name] = module
+
+        # Load model itself
         with open(directory / self.MODEL_PICKLE_FILE, mode="rb") as file:
             model = pickle.load(file)  # nosec
             return ModelRuntimeObjects(

--- a/layer/flavors/custom.py
+++ b/layer/flavors/custom.py
@@ -46,11 +46,11 @@ class CustomModelFlavor(ModelFlavor):
     ) -> None:
         directory.mkdir(parents=True, exist_ok=True)
         with open(directory / self.MODEL_PICKLE_FILE, mode="wb") as file:
-            cloudpickle.dump(model_object, file, protocol=pickle.DEFAULT_PROTOCOL)
+            pickle.dump(model_object, file, protocol=pickle.DEFAULT_PROTOCOL)
 
     def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
         with open(directory / self.MODEL_PICKLE_FILE, mode="rb") as file:
-            model = cloudpickle.load(file)
+            model = pickle.load(file)
             return ModelRuntimeObjects(
                 model, lambda input_df: self.__predict(model, input_df)
             )

--- a/layer/flavors/custom.py
+++ b/layer/flavors/custom.py
@@ -1,9 +1,8 @@
-import pickle
+import pickle  # nosec
 from abc import abstractmethod
 from pathlib import Path
 from typing import Any
 
-import cloudpickle  # type: ignore
 import pandas
 from layerapi.api.entity.model_version_pb2 import ModelVersion
 
@@ -50,7 +49,7 @@ class CustomModelFlavor(ModelFlavor):
 
     def load_model_from_directory(self, directory: Path) -> ModelRuntimeObjects:
         with open(directory / self.MODEL_PICKLE_FILE, mode="rb") as file:
-            model = pickle.load(file)
+            model = pickle.load(file)  # nosec
             return ModelRuntimeObjects(
                 model, lambda input_df: self.__predict(model, input_df)
             )

--- a/test/unit/common/dummy_model.py
+++ b/test/unit/common/dummy_model.py
@@ -1,5 +1,6 @@
 import layer
 
+
 class DummyModel(layer.CustomModel):
     def __init__(self):
         super().__init__()

--- a/test/unit/common/dummy_model.py
+++ b/test/unit/common/dummy_model.py
@@ -1,7 +1,6 @@
-from layer import CustomModel
+import layer
 
-
-class DummyModel(CustomModel):
+class DummyModel(layer.CustomModel):
     def __init__(self):
         super().__init__()
 

--- a/test/unit/common/dummy_model.py
+++ b/test/unit/common/dummy_model.py
@@ -1,0 +1,17 @@
+from layer import CustomModel
+
+
+class DummyModel(CustomModel):
+    def __init__(self):
+        super().__init__()
+
+        from sklearn.datasets import load_iris
+        from sklearn.svm import SVC
+
+        svc = SVC()
+        x, y = load_iris(return_X_y=True)
+        svc.fit(x, y)
+        self.model = svc
+
+    def predict(self, model_input):
+        return self.model.predict(model_input)

--- a/test/unit/test_custom_model.py
+++ b/test/unit/test_custom_model.py
@@ -1,0 +1,27 @@
+# type: ignore
+import logging
+from layer.flavors import CustomModelFlavor
+
+logger = logging.getLogger(__name__)
+
+
+class TestModelFlavors:
+
+    def test_custom_flavor(self, tmp_path):
+        from sklearn.datasets import load_iris
+        from sklearn.svm import SVC
+        import layer
+
+        from .common.dummy_model import DummyModel
+
+        model = DummyModel()
+        flavor = CustomModelFlavor()
+
+        flavor.save_model_to_directory(model, tmp_path)
+        loaded_model = flavor.load_model_from_directory(tmp_path).model_object
+        assert isinstance(loaded_model, layer.CustomModel)
+        assert isinstance(loaded_model.model, SVC)
+
+        x, _ = load_iris(return_X_y=True)
+        result = loaded_model.predict(x[:5])
+        assert list(result) == [0, 0, 0, 0, 0]

--- a/test/unit/test_custom_model.py
+++ b/test/unit/test_custom_model.py
@@ -1,17 +1,12 @@
 # type: ignore
-import logging
 from layer.flavors import CustomModelFlavor
-
-logger = logging.getLogger(__name__)
 
 
 class TestModelFlavors:
-
-    def test_custom_flavor(self, tmp_path):
-        from sklearn.datasets import load_iris
+    def test_custom_model_save_load(self, tmp_path):
         from sklearn.svm import SVC
-        import layer
-
+        import pandas as pd
+        from layer import CustomModel
         from .common.dummy_model import DummyModel
 
         model = DummyModel()
@@ -19,9 +14,9 @@ class TestModelFlavors:
 
         flavor.save_model_to_directory(model, tmp_path)
         loaded_model = flavor.load_model_from_directory(tmp_path).model_object
-        assert isinstance(loaded_model, layer.CustomModel)
+        assert isinstance(loaded_model, CustomModel)
         assert isinstance(loaded_model.model, SVC)
 
-        x, _ = load_iris(return_X_y=True)
-        result = loaded_model.predict(x[:5])
-        assert list(result) == [0, 0, 0, 0, 0]
+        df = pd.DataFrame([[1, 2, 3, 4]])
+        result = loaded_model.predict(df)
+        assert list(result) is not None

--- a/test/unit/test_custom_model.py
+++ b/test/unit/test_custom_model.py
@@ -1,12 +1,15 @@
 # type: ignore
+import layer
 from layer.flavors import CustomModelFlavor
 
 
 class TestModelFlavors:
     def test_custom_model_save_load(self, tmp_path):
-        from sklearn.svm import SVC
         import pandas as pd
+        from sklearn.svm import SVC
+
         from layer import CustomModel
+
         from .common.dummy_model import DummyModel
 
         model = DummyModel()
@@ -20,3 +23,19 @@ class TestModelFlavors:
         df = pd.DataFrame([[1, 2, 3, 4]])
         result = loaded_model.predict(df)
         assert list(result) is not None
+
+    def test_custom_model_save_fails(self, tmp_path):
+        import pandas as pd
+
+        class CustomLocalModel(layer.CustomModel):
+            def predict(self, model_input: pd.DataFrame) -> pd.DataFrame:
+                pass
+
+        model = CustomLocalModel()
+        flavor = CustomModelFlavor()
+
+        try:
+            flavor.save_model_to_directory(model, tmp_path)
+            assert False
+        except Exception:
+            assert True

--- a/test/unit/test_model_flavor.py
+++ b/test/unit/test_model_flavor.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 
-import layer
 from layer.flavors import (
     CatBoostModelFlavor,
     CustomModelFlavor,
@@ -245,9 +244,6 @@ class TestModelFlavors:
         assert model.__class__.__name__ == "AutoShape"
 
     def test_custom_flavor(self, tmp_path):
-        from sklearn.datasets import load_iris
-        from sklearn.svm import SVC
-
         from .common.dummy_model import DummyModel
 
         model = DummyModel()

--- a/test/unit/test_model_flavor.py
+++ b/test/unit/test_model_flavor.py
@@ -253,12 +253,3 @@ class TestModelFlavors:
         model = DummyModel()
         flavor = get_flavor_for_model(model)
         assert type(flavor).__name__ == CustomModelFlavor.__name__
-
-        flavor.save_model_to_directory(model, tmp_path)
-        loaded_model = flavor.load_model_from_directory(tmp_path).model_object
-        assert isinstance(loaded_model, layer.CustomModel)
-        assert isinstance(loaded_model.model, SVC)
-
-        x, _ = load_iris(return_X_y=True)
-        result = loaded_model.predict(x[:5])
-        assert list(result) == [0, 0, 0, 0, 0]

--- a/test/unit/test_model_flavor.py
+++ b/test/unit/test_model_flavor.py
@@ -266,7 +266,7 @@ class TestModelFlavors:
         flavor = get_flavor_for_model(model)
         assert type(flavor).__name__ == CustomModelFlavor.__name__
 
-        flavor.save_model_to_directory(model, tmp_path)
+        flavor.save_model_to_directory(DummyModel(), tmp_path)
         loaded_model = flavor.load_model_from_directory(tmp_path).model_object
         assert isinstance(loaded_model, layer.CustomModel)
         assert isinstance(loaded_model.model, SVC)

--- a/test/unit/test_model_flavor.py
+++ b/test/unit/test_model_flavor.py
@@ -248,25 +248,13 @@ class TestModelFlavors:
         from sklearn.datasets import load_iris
         from sklearn.svm import SVC
 
-        from layer import CustomModel
-
-        class DummyModel(CustomModel):
-            def __init__(self):
-                super().__init__()
-                svc = SVC()
-                svc.set_params(kernel="linear")
-                x, y = load_iris(return_X_y=True)
-                svc.fit(x, y)
-                self.model = svc
-
-            def predict(self, model_input):
-                return self.model.predict(model_input)
+        from .common.dummy_model import DummyModel
 
         model = DummyModel()
         flavor = get_flavor_for_model(model)
         assert type(flavor).__name__ == CustomModelFlavor.__name__
 
-        flavor.save_model_to_directory(DummyModel(), tmp_path)
+        flavor.save_model_to_directory(model, tmp_path)
         loaded_model = flavor.load_model_from_directory(tmp_path).model_object
         assert isinstance(loaded_model, layer.CustomModel)
         assert isinstance(loaded_model.model, SVC)


### PR DESCRIPTION
Previous custom model pickle routine was using Cloudpickle which was causing errors to load a custom model in different python versions. Now we use plain pickle to serialize and load the model.