### PR TITLE
Adjust description color for SDK UI

### DIFF
--- a/layer/tracker/asset_column.py
+++ b/layer/tracker/asset_column.py
@@ -350,14 +350,13 @@ class AssetColumn(ProgressColumn):
         else:
             text = task.description
         if (
-            asset.status == AssetTrackerStatus.RESOURCE_UPLOADING
-            or asset.status == AssetTrackerStatus.RESULT_UPLOADING
-            or asset.status == AssetTrackerStatus.ASSET_DOWNLOADING
-            or asset.status == AssetTrackerStatus.ASSET_FROM_CACHE
+            asset.status == AssetTrackerStatus.ASSET_LOADED
+            or asset.status == AssetTrackerStatus.DONE
+            or asset.status == AssetTrackerStatus.ERROR
         ):
-            style = ProgressStyle.BLACK
-        else:
             style = self._status_style_map[asset.status]
+        else:
+            style = ProgressStyle.GRAY
         return Text(
             text.upper(),
             overflow="fold",


### PR DESCRIPTION
Adjusts the status color to gray, which is readable in both CLI, light and dark notebook themes.

<img width="862" alt="Screen Shot 2022-06-01 at 15 24 04" src="https://user-images.githubusercontent.com/1766321/171449977-85229f24-c7fa-4983-be56-2fc3b9bad01b.png">
<img width="756" alt="Screen Shot 2022-06-01 at 15 23 09" src="https://user-images.githubusercontent.com/1766321/171449990-385262cb-5c93-42f0-88a6-94114b5fa035.png">
<img width="756" alt="Screen Shot 2022-06-01 at 15 23 09" src="https://user-images.githubusercontent.com/1766321/171450610-1222602d-c2ad-45cb-96e2-c126795918d5.png">




