### PR TITLE
Clarify pre-requirements to use SDK with Apple M1 devices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,9 +121,12 @@ We recommend using `pyenv`
 
 Please run `pyenv install $(cat .python-version)` in the root of this repository to setup the recommended python version.
 
-If you are using an M1 machine, we recommend using `conda`. Please run
+If you are using an M1 machine, we recommend using `conda` via [Miniforge3](https://github.com/conda-forge/miniforge/). Please run
 
 ```
+# Install Miniforge3 if required
+/bin/bash -c "$(curl -fsSL https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh)"
+# Create and activate conda environment
 conda create -yq -n sdk python=3.8 tokenizers==0.12.1 xgboost==1.5.1 lightgbm==3.3.2 poetry h5py==3.6.0 pyarrow==7.0.0
 conda activate sdk
 ```


### PR DESCRIPTION
Fix current instructions on M1 pre-requirements. We expected conda to be used based on Apple recomendation of Miniforge3 from conda-forge. This will ensure that `make install` and `make test` work correctly on Apple M1 devices.