### PR TITLE
Simplify setup pre-requirements on Apple arm processors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ If you are using an M1 machine, we recommend using `conda` via [Miniforge3](http
 # Install Miniforge3 if required
 /bin/bash -c "$(curl -fsSL https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh)"
 # Create and activate conda environment
-conda create -yq -n sdk python=3.8 tokenizers==0.12.1 xgboost==1.5.1 lightgbm==3.3.2 poetry h5py==3.6.0 pyarrow==7.0.0
+conda create -yq -n sdk python=3.8
 conda activate sdk
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,22 @@ UNAME_ARCH := $(shell uname -m)
 
 .DEFAULT_GOAL:=help
 
-install: $(INSTALL_STAMP) ## Install dependencies
+define get_python_package_version
+  $(1)==$(shell $(POETRY) show $1 --no-ansi --no-dev | grep version | awk '{print $$3}')
+endef
+
+install: apple-arm-prereq-install $(INSTALL_STAMP) ## Install dependencies
 $(INSTALL_STAMP): pyproject.toml poetry.lock
 	@if [ -z $(POETRY) ]; then echo "Poetry could not be found. See https://python-poetry.org/docs/"; exit 2; fi
+ifdef IN_VENV
+	$(POETRY) install
+else
+	$(POETRY) install --remove-untracked
+endif
+	touch $(INSTALL_STAMP)
+
+.PHONY: apple-arm-prereq-install
+apple-arm-prereq-install:
 ifeq ($(UNAME_SYS), Darwin)
 ifeq ($(UNAME_ARCH), arm64)
 ifdef CONDA_ENV_NAME
@@ -20,12 +33,11 @@ ifeq ($(CONDA_ENV_NAME), base)
 	@echo 'Please create a conda environment and make it active'
 	@exit 1
 else
-	$(eval TOKENIZERS_VERSION := $(shell poetry show tokenizers --no-ansi --no-dev | grep version | awk '{print $$3}'))
-	$(eval XGBOOST_VERSION := $(shell poetry show xgboost --no-ansi --no-dev | grep version | awk '{print $$3}'))
-	$(eval LIGHTGBM_VERSION := $(shell poetry show lightgbm --no-ansi --no-dev | grep version | awk '{print $$3}'))
-	$(eval H5PY_VERSION := $(shell poetry show h5py --no-ansi --no-dev | grep version | awk '{print $$3}'))
-	$(eval PYARROW_VERSION := $(shell poetry show pyarrow --no-ansi --no-dev | grep version | awk '{print $$3}'))
-	@conda install -y tokenizers==$(TOKENIZERS_VERSION) xgboost==$(XGBOOST_VERSION) lightgbm==$(LIGHTGBM_VERSION) h5py==$(H5PY_VERSION) pyarrow==$(PYARROW_VERSION)
+	@conda install -y $(call get_python_package_version,tokenizers) \
+                         $(call get_python_package_version,xgboost) \
+                         $(call get_python_package_version,lightgbm) \
+                         $(call get_python_package_version,h5py) \
+                         $(call get_python_package_version,pyarrow)
 endif
 else
 	@echo 'Not inside a conda environment or conda not installed, this is a requirement for Apple arm processors'
@@ -34,12 +46,6 @@ else
 endif
 endif
 endif
-ifdef IN_VENV
-	$(POETRY) install
-else
-	$(POETRY) install --remove-untracked
-endif
-	touch $(INSTALL_STAMP)
 
 .PHONY: test
 test: $(INSTALL_STAMP) ## Run unit tests


### PR DESCRIPTION
Avoid requiring specific package versions added manually to Conda environment and detect correct environment is available