### PR TITLE
Step support for log.layer IMAGE

### DIFF
--- a/layer/contracts/logged_data.py
+++ b/layer/contracts/logged_data.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum, unique
+from typing import Dict
 
 
 @unique
@@ -20,6 +21,7 @@ class LoggedData:
     logged_data_type: LoggedDataType
     tag: str
     data: str
+    epoched_data: Dict[int, str]
 
 
 @dataclass(frozen=True)

--- a/layer/main.py
+++ b/layer/main.py
@@ -681,7 +681,7 @@ def log(
 ) -> None:
     """
     :param data: A dictionary in which each key is a string tag (i.e. name/id). The value can have different types. See examples below for more details.
-    :param step: An optional integer that associates data with a particular step (epoch). This only takes effect it the logged data is to be associated with a model train (and *not* with a dataset build) and the data is a number.
+    :param step: An optional positive integer that associates data with a particular step (epoch). This only takes effect if the logged data is to be associated with a model train (and *not* with a dataset build), and the data is either a number or an image.
     :return: None
 
     Logs arbitrary data associated with a model train or a dataset build into Layer backend.

--- a/test/e2e/test_log_types.py
+++ b/test/e2e/test_log_types.py
@@ -123,6 +123,7 @@ def test_image_and_video_logged(initialized_project: Project, client: LayerClien
     pil_image_tag = "pil_image_tag"
     image_path_tag = "image_path_tag"
     video_path_tag = "video_path_tag"
+    stepped_pil_image_tab = "stepped_pil_image_tag"
 
     @dataset(ds_name)
     def multimedia():
@@ -139,6 +140,9 @@ def test_image_and_video_logged(initialized_project: Project, client: LayerClien
 
         video_path = Path(f"{os.getcwd()}/test/e2e/assets/log_assets/layer_video.mp4")
         layer.log({video_path_tag: video_path})
+
+        for step in range(4, 6):
+            layer.log({stepped_pil_image_tab: image}, step=step)
 
         return pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
 
@@ -166,6 +170,16 @@ def test_image_and_video_logged(initialized_project: Project, client: LayerClien
     assert logged_data.data.startswith("https://logged-data--layer")
     assert logged_data.data.endswith(video_path_tag)
     assert logged_data.logged_data_type == LoggedDataType.VIDEO
+
+    logged_data = client.logged_data_service_client.get_logged_data(
+        tag=stepped_pil_image_tab, dataset_build_id=ds.build.id
+    )
+    assert logged_data.logged_data_type == LoggedDataType.IMAGE
+    assert len(logged_data.epoched_data) == 2
+    assert logged_data.epoched_data[4].value.startswith("https://logged-data--layer")
+    assert logged_data.epoched_data[4].value.endswith(stepped_pil_image_tab)
+    assert logged_data.epoched_data[5].value.startswith("https://logged-data--layer")
+    assert logged_data.epoched_data[5].value.endswith(stepped_pil_image_tab)
 
 
 def test_matplotlib_objects_logged(initialized_project: Project, client: LayerClient):

--- a/test/e2e/test_log_types.py
+++ b/test/e2e/test_log_types.py
@@ -199,10 +199,10 @@ def test_image_and_video_logged(initialized_project: Project, client: LayerClien
     )
     assert logged_data.logged_data_type == LoggedDataType.IMAGE
     assert len(logged_data.epoched_data) == 2
-    assert logged_data.epoched_data[4].value.startswith("https://logged-data--layer")
-    assert logged_data.epoched_data[4].value.endswith(stepped_pil_image_tab)
-    assert logged_data.epoched_data[5].value.startswith("https://logged-data--layer")
-    assert logged_data.epoched_data[5].value.endswith(stepped_pil_image_tab)
+    assert logged_data.epoched_data[4].startswith("https://logged-data--layer")
+    assert logged_data.epoched_data[4].endswith(stepped_pil_image_tab)
+    assert logged_data.epoched_data[5].startswith("https://logged-data--layer")
+    assert logged_data.epoched_data[5].endswith(stepped_pil_image_tab)
 
 
 def test_matplotlib_objects_logged(initialized_project: Project, client: LayerClient):

--- a/test/e2e/test_log_types.py
+++ b/test/e2e/test_log_types.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 import pandas as pd
 from sklearn.svm import SVC
 
@@ -193,7 +195,7 @@ def test_image_and_video_logged(initialized_project: Project, client: LayerClien
 
     mdl = layer.get_model(model_name)
     logged_data = client.logged_data_service_client.get_logged_data(
-        tag=stepped_pil_image_tab, train_id=mdl.storage_config.train_id
+        tag=stepped_pil_image_tab, train_id=UUID(mdl.storage_config.train_id.value)
     )
     assert logged_data.logged_data_type == LoggedDataType.IMAGE
     assert len(logged_data.epoched_data) == 2

--- a/test/e2e/test_log_types.py
+++ b/test/e2e/test_log_types.py
@@ -200,9 +200,9 @@ def test_image_and_video_logged(initialized_project: Project, client: LayerClien
     assert logged_data.logged_data_type == LoggedDataType.IMAGE
     assert len(logged_data.epoched_data) == 2
     assert logged_data.epoched_data[4].startswith("https://logged-data--layer")
-    assert logged_data.epoched_data[4].endswith(stepped_pil_image_tab)
+    assert logged_data.epoched_data[4].endswith(f"{stepped_pil_image_tab}/epoch/4")
     assert logged_data.epoched_data[5].startswith("https://logged-data--layer")
-    assert logged_data.epoched_data[5].endswith(stepped_pil_image_tab)
+    assert logged_data.epoched_data[5].endswith(f"{stepped_pil_image_tab}/epoch/5")
 
 
 def test_matplotlib_objects_logged(initialized_project: Project, client: LayerClient):

--- a/test/e2e/test_log_types.py
+++ b/test/e2e/test_log_types.py
@@ -1,10 +1,11 @@
 import pandas as pd
+from sklearn.svm import SVC
 
 import layer
 from layer.clients.layer import LayerClient
 from layer.contracts.logged_data import LoggedDataType
 from layer.contracts.projects import Project
-from layer.decorators import dataset, model
+from layer.decorators import dataset, model, pip_requirements
 from test.e2e.assertion_utils import E2ETestAsserter
 
 
@@ -169,15 +170,24 @@ def test_image_and_video_logged(initialized_project: Project, client: LayerClien
     assert logged_data.data.endswith(video_path_tag)
     assert logged_data.logged_data_type == LoggedDataType.VIDEO
 
+    @pip_requirements(packages=["scikit-learn==0.23.2"])
     @model(model_name)
     def train_model():
         import os
 
         from PIL import Image
+        from sklearn import datasets
+
+        iris = datasets.load_iris()
+        clf = SVC()
+        result = clf.fit(iris.data, iris.target)
 
         image = Image.open(f"{os.getcwd()}/test/e2e/assets/log_assets/layer_logo.jpeg")
         for step in range(4, 6):
             layer.log({stepped_pil_image_tab: image}, step=step)
+
+        print("model1 computed")
+        return result
 
     train_model()
 

--- a/test/e2e/test_log_types.py
+++ b/test/e2e/test_log_types.py
@@ -188,7 +188,7 @@ def test_image_and_video_logged(initialized_project: Project, client: LayerClien
         for step in range(4, 6):
             layer.log({stepped_pil_image_tab: image}, step=step)
 
-        print("model1 computed")
+        print("model1 computed fully")
         return result
 
     train_model()

--- a/test/e2e/test_log_types.py
+++ b/test/e2e/test_log_types.py
@@ -193,7 +193,7 @@ def test_image_and_video_logged(initialized_project: Project, client: LayerClien
 
     mdl = layer.get_model(model_name)
     logged_data = client.logged_data_service_client.get_logged_data(
-        tag=stepped_pil_image_tab, train_id=mdl.get_train().id
+        tag=stepped_pil_image_tab, train_id=mdl.storage_config.train_id
     )
     assert logged_data.logged_data_type == LoggedDataType.IMAGE
     assert len(logged_data.epoched_data) == 2

--- a/test/unit/logged_data/test_logged_data_service_client.py
+++ b/test/unit/logged_data/test_logged_data_service_client.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest.mock import MagicMock
 
+import pytest
 from layerapi.api.entity.logged_model_metric_pb2 import LoggedModelMetric
 from layerapi.api.ids_pb2 import LoggedDataId, ModelMetricId, ModelTrainId
 from layerapi.api.service.logged_data.logged_data_api_pb2 import (
@@ -16,7 +17,33 @@ from layer.clients.logged_data_service import ModelMetricPoint
 from .util import get_logged_data_service_client_with_mocks
 
 
-def test_given_tag_not_exists_when_log_text_then_calls_log_data_with_text_type():  # noqa
+@pytest.mark.parametrize(
+    ("tag", "text", "fnc_name", "log_type"),
+    [
+        (
+            "table-test-tag",
+            "{}",
+            "log_table_data",
+            LoggedDataType.LOGGED_DATA_TYPE_TABLE,
+        ),
+        ("text-test-tag", "abc", "log_text_data", LoggedDataType.LOGGED_DATA_TYPE_TEXT),
+        (
+            "num-test-tag",
+            "123",
+            "log_numeric_data",
+            LoggedDataType.LOGGED_DATA_TYPE_NUMBER,
+        ),
+        (
+            "bool-test-tag",
+            "True",
+            "log_boolean_data",
+            LoggedDataType.LOGGED_DATA_TYPE_BOOLEAN,
+        ),
+    ],
+)
+def test_given_tag_not_exists_when_log_x_then_calls_log_data_with_x_type(
+    tag, text, fnc_name, log_type
+):  # noqa
     # given
     mock_logged_data_api = MagicMock()
     mock_logged_data_api.LogData.return_value = LogDataResponse(
@@ -26,46 +53,21 @@ def test_given_tag_not_exists_when_log_text_then_calls_log_data_with_text_type()
         logged_data_api_stub=mock_logged_data_api
     )
     train_id = uuid.uuid4()
-    tag = "test-tag"
-    text = "test-text"
+    # tag = "table-test-tag"
+    # data = "{}"
 
     # when
-    logged_data_client.log_text_data(train_id=train_id, tag=tag, data=text)
+    fnc = getattr(logged_data_client, fnc_name)
+    fnc(train_id=train_id, tag=tag, data=text)
 
     # then
     mock_logged_data_api.LogData.assert_called_with(
         request=LogDataRequest(
             model_train_id=ModelTrainId(value=str(train_id)),
             unique_tag=tag,
-            type=LoggedDataType.LOGGED_DATA_TYPE_TEXT,
+            type=log_type,
             text=text,
-        )
-    )
-
-
-def test_given_tag_not_exists_when_log_table_then_calls_log_data_with_table_type():  # noqa
-    # given
-    mock_logged_data_api = MagicMock()
-    mock_logged_data_api.LogData.return_value = LogDataResponse(
-        logged_data_id=LoggedDataId(value="00000000-0000-0000-0000-000000000000")
-    )
-    logged_data_client = get_logged_data_service_client_with_mocks(
-        logged_data_api_stub=mock_logged_data_api
-    )
-    train_id = uuid.uuid4()
-    tag = "table-test-tag"
-    data = "{}"
-
-    # when
-    logged_data_client.log_table_data(train_id=train_id, tag=tag, data=data)
-
-    # then
-    mock_logged_data_api.LogData.assert_called_with(
-        request=LogDataRequest(
-            model_train_id=ModelTrainId(value=str(train_id)),
-            unique_tag=tag,
-            type=LoggedDataType.LOGGED_DATA_TYPE_TABLE,
-            text=data,
+            epoch=-1,
         )
     )
 
@@ -82,12 +84,14 @@ def test_given_tag_not_exists_when_log_binary_then_calls_log_data_with_image_typ
     )
     train_id = uuid.uuid4()
     tag = "image-test-tag"
+    epoch = 123
 
     # when
     s3_path = logged_data_client.log_binary_data(
         train_id=train_id,
         tag=tag,
         logged_data_type=LoggedDataType.LOGGED_DATA_TYPE_IMAGE,
+        epoch=epoch,
     )
 
     # then
@@ -97,6 +101,7 @@ def test_given_tag_not_exists_when_log_binary_then_calls_log_data_with_image_typ
             unique_tag=tag,
             type=LoggedDataType.LOGGED_DATA_TYPE_IMAGE,
             text=None,
+            epoch=epoch,
         )
     )
     assert s3_path == "path/to/upload"


### PR DESCRIPTION
Previously, the `step` argument of `layer.log` only worked for numeric values. As of this change, we also support images as well (both PIL.Image and image files)