### PR TITLE
Disable jupyter rich rendering

### DIFF
--- a/layer/tracker/output.py
+++ b/layer/tracker/output.py
@@ -67,7 +67,9 @@ class SpinnerColumn(ProgressColumn):
 
 def get_progress_ui() -> Progress:
     return Progress(
-        SpinnerColumn(finished_text=":white_heavy_check_mark:"), AssetColumn()
+        SpinnerColumn(finished_text=":white_heavy_check_mark:"),
+        AssetColumn(),
+        console=Console(force_jupyter=False),
     )
 
 


### PR DESCRIPTION
Rendering the progress ui in Google Colab appears to cause crashes due to an identified version mismatch.

Disable the progress UI in jupyter temporarily until we find a proper solution