### PR TITLE
Compute number of rows per batch slice dynamically

### DIFF
--- a/layer/clients/data_catalog.py
+++ b/layer/clients/data_catalog.py
@@ -438,11 +438,13 @@ def _get_batch_chunks(
     """
 
     bytes_per_row = batch.nbytes / batch.num_rows  # average row size
-    max_num_rows = int(max_chunk_size_bytes / bytes_per_row)  # rows per chunk
-    if max_num_rows == 0:
+    if bytes_per_row > max_chunk_size_bytes:
         raise ValueError(
             f"the average size of a single row of {int(bytes_per_row)} byte(s) exceeds max chunk size of {max_chunk_size_bytes} byte(s)"
         )
+    max_num_rows = int(
+        max_chunk_size_bytes / bytes_per_row
+    )  # how many rows fit into the chunk
     start = 0
     while start < batch.num_rows:
         i = max_num_rows

--- a/layer/clients/data_catalog.py
+++ b/layer/clients/data_catalog.py
@@ -433,7 +433,7 @@ def _get_batch_chunks(
     batch: pyarrow.RecordBatch, max_chunk_size_bytes: int = 4_000_000
 ) -> Generator[pyarrow.RecordBatch, None, None]:
     """
-    Slice the batch into the chunks, based on average row size,
+    Slice the batch into chunks, based on average row size,
     but not exceeding the maximum chunk size.
     """
 

--- a/test/unit/test_get_batch_chunks.py
+++ b/test/unit/test_get_batch_chunks.py
@@ -1,0 +1,78 @@
+import re
+
+import pyarrow as pa
+import pytest
+
+from layer.clients.data_catalog import _get_batch_chunks
+
+
+def test_get_batch_chunks_returns_single_chunk():
+    data = ["aaa", "bbb", "ccc"]
+    batch = pa.RecordBatch.from_arrays([pa.array(data)], names=["data"])
+    chunks = [chunk.to_pydict() for chunk in _get_batch_chunks(batch)]
+
+    assert chunks == [{"data": data}]
+
+
+def test_get_batch_chunks_returns_multiple_chunks():
+    data = ["a" * 3, "b" * 3, "c" * 3, "d" * 3, "e" * 2]
+    batch = pa.RecordBatch.from_arrays([pa.array(data)], names=["data"])
+    chunks = [
+        chunk.to_pydict() for chunk in _get_batch_chunks(batch, max_chunk_size_bytes=15)
+    ]
+
+    assert chunks == [
+        {"data": ["aaa", "bbb"]},
+        {"data": ["ccc", "ddd"]},
+        {"data": ["ee"]},
+    ]
+
+
+def test_get_batch_chunks_raises_when_average_row_size_exceeds_chunk_size():
+    data = ["a" * 3, "b" * 3, "c" * 3, "d" * 3, "e" * 2]
+    batch = pa.RecordBatch.from_arrays([pa.array(data)], names=["data"])
+
+    expected = re.escape(
+        "the average size of a single row of 6 byte(s) exceeds max chunk size of 5 byte(s)"
+    )
+    with pytest.raises(ValueError, match=expected):
+        list(_get_batch_chunks(batch, max_chunk_size_bytes=5))
+
+
+def test_get_batch_chunks_reduces_num_rows_if_chunk_size_exceeded():
+    data = ["a" * 3, "b" * 3, "c" * 11, "d" * 3, "e" * 2]
+    batch = pa.RecordBatch.from_arrays([pa.array(data)], names=["data"])
+    chunks = [
+        chunk.to_pydict() for chunk in _get_batch_chunks(batch, max_chunk_size_bytes=15)
+    ]
+
+    assert chunks == [
+        {"data": ["aaa"]},
+        {"data": ["bbb"]},
+        {"data": ["ccccccccccc"]},
+        {"data": ["ddd"]},
+        {"data": ["ee"]},
+    ]
+
+
+def test_get_batch_chunks_raises_when_single_row_size_exceeds_chunk_size():
+    data = ["a" * 3, "b" * 3, "c" * 17, "d" * 3, "e" * 2]
+    batch = pa.RecordBatch.from_arrays([pa.array(data)], names=["data"])
+    expected = re.escape(
+        "single row in the batch at index 2 exceeds max chunk size of 15 byte(s)"
+    )
+    with pytest.raises(ValueError, match=expected):
+        list(_get_batch_chunks(batch, max_chunk_size_bytes=15))
+
+
+def test_get_batch_chunks_item_size_multiple_of_chunk_size():
+    data = ["a" * 3, "b" * 3, "c" * 3, "d" * 3]
+    batch = pa.RecordBatch.from_arrays([pa.array(data)], names=["data"])
+    chunks = [
+        chunk.to_pydict() for chunk in _get_batch_chunks(batch, max_chunk_size_bytes=14)
+    ]
+
+    assert chunks == [
+        {"data": ["aaa", "bbb"]},
+        {"data": ["ccc", "ddd"]},
+    ]


### PR DESCRIPTION
Instead of having a hardcoded chunk size set to a very small value, compute the chunk size of the batch dynamically. This should significantly improve the throughput for `store_dataset`.

