### PR TITLE
Fix rich UI in notebook environments

### DIFF
--- a/layer/main.py
+++ b/layer/main.py
@@ -574,7 +574,6 @@ def run(functions: List[Any], debug: bool = False) -> Run:
     project_full_name = _get_project_full_name(layer_config, get_current_project_name())
     project_runner = ProjectRunner(config=layer_config)
     run = project_runner.with_functions(project_full_name, functions)
-    print("Running Layer project...")
     run = project_runner.run(run, debug=debug)
 
     _make_notebook_links_open_in_new_tab()

--- a/layer/tracker/output.py
+++ b/layer/tracker/output.py
@@ -69,7 +69,7 @@ def get_progress_ui() -> Progress:
     return Progress(
         SpinnerColumn(finished_text=":white_heavy_check_mark:"),
         AssetColumn(),
-        console=Console(force_jupyter=False),
+        console=Console(),
     )
 
 

--- a/layer/tracker/progress_tracker.py
+++ b/layer/tracker/progress_tracker.py
@@ -36,11 +36,25 @@ class RunProgressTracker(abc.ABC):
         self._progress = get_progress_ui()
         self._tasks: Dict[Tuple[AssetType, str], Task] = {}
 
+    @staticmethod
+    def __google_colab_ipykernel_fix() -> None:
+        """
+        Fixes https://linear.app/layer/issue/LAY-3286/replace-rich-as-a-dependency-for-the-ui-of-the-sdk
+        """
+        import logging.config
+        logging.config.dictConfig(
+            {
+                "version": 1,
+                "disable_existing_loggers": False,
+            }
+        )
+
     @contextmanager
     def track(self) -> Iterator["RunProgressTracker"]:
         """
         Initializes tracking. Meant to be used with a `with` construct.
         """
+        self.__google_colab_ipykernel_fix()
         with self._progress:
             self._init_tasks()
             yield self

--- a/layer/tracker/progress_tracker.py
+++ b/layer/tracker/progress_tracker.py
@@ -40,8 +40,11 @@ class RunProgressTracker(abc.ABC):
     def __google_colab_ipykernel_fix() -> None:
         """
         Fixes https://linear.app/layer/issue/LAY-3286/replace-rich-as-a-dependency-for-the-ui-of-the-sdk
+        It works by clearing the logger handlers as some of them appear to be interacting with the same resources
+        rich interacts with, leading to hitting a bug in old ipykernel-s(<5.2) (https://github.com/ipython/ipykernel/pull/463)
         """
         import logging.config
+
         logging.config.dictConfig(
             {
                 "version": 1,


### PR DESCRIPTION
Tested on Google Colab and local Jupyter notebook environments that it works.
The clearing of the logging handlers seems to be non-disruptive, and it's effectively done as soon as you import the `mlflow` library anyway. 