### PR TITLE
Remove sdk dependencies clashing with Colab runtime

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1741,7 +1741,7 @@ prometheus-client = "*"
 name = "prompt-toolkit"
 version = "3.0.29"
 description = "Library for building powerful interactive command lines in Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6.2"
 
@@ -2743,7 +2743,7 @@ testing = ["pytest", "pytest-cover", "coverage (>=5.0)"]
 name = "wcwidth"
 version = "0.2.5"
 description = "Measures the displayed width of unicode strings in a terminal"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -2856,7 +2856,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.11"
-content-hash = "73ac69ffe30485adde3b74c8ae7c86416f44a83117e135008325dd79cc2b27d7"
+content-hash = "d99bfc6b6baf31779f78c2a39a6c30bbf4d7618ceb61a464dfe39cea55621d71"
 
 [metadata.files]
 absl-py = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ packaging = "<=21.0"  # latest release (21.2) is causing version conflicts with 
 pandas = "1.3.5"
 pickle5 = { version = "~0.0.11", python = "<3.8" }
 polling  = ">=0.3.1"
-prompt_toolkit  = ">=3.0.8"
 protobuf  = ">=3.12.0"
 pyarrow = "7.0.0"
 pyjwt  = "^2.0.0"


### PR DESCRIPTION
This is an unused dependency that clashes with the Colab runtime.
Before the change and output of installing layer sdk:
![image (2)](https://user-images.githubusercontent.com/1766321/174280771-56ba2bcf-bf4e-4d5c-a7c8-9d2854d8abae.png)
After the change and output of installing the layer sdk:
![Screen Shot 2022-06-17 at 13 27 07](https://user-images.githubusercontent.com/1766321/174280893-fc9a40e9-5360-49f2-a41c-1f7ae4b9e37b.png)

