### PR TITLE
Check supported Python version

### DIFF
--- a/layer/global_context.py
+++ b/layer/global_context.py
@@ -16,6 +16,8 @@ class GlobalContext:
     # We show a message to the user if their installed layer version is outdated.
     # We want to avoid showing this in case we already checked the version or we have already shown this message.
     has_shown_update_message: bool
+    # Similar to above, but for supported Python version.
+    has_shown_python_version_message: bool
 
 
 # We store project name, fabric, active context and requirements
@@ -27,6 +29,7 @@ _GLOBAL_CONTEXT = GlobalContext(
     pip_requirements_file=None,
     pip_packages=None,
     has_shown_update_message=False,
+    has_shown_python_version_message=False,
 )
 
 
@@ -41,6 +44,7 @@ def reset_to(project_full_name: Optional[Union[str, ProjectFullName]]) -> None:
             pip_requirements_file=None,
             pip_packages=None,
             has_shown_update_message=False,
+            has_shown_python_version_message=False,
         )
 
 
@@ -137,3 +141,11 @@ def set_has_shown_update_message(shown: bool) -> None:
 
 def has_shown_update_message() -> bool:
     return _GLOBAL_CONTEXT.has_shown_update_message
+
+
+def set_has_shown_python_version_message(shown: bool) -> None:
+    _GLOBAL_CONTEXT.has_shown_python_version_message = shown
+
+
+def has_shown_python_version_message() -> bool:
+    return _GLOBAL_CONTEXT.has_shown_python_version_message

--- a/layer/main.py
+++ b/layer/main.py
@@ -44,10 +44,12 @@ from layer.global_context import (
     current_project_full_name,
     current_project_name,
     get_active_context,
+    has_shown_python_version_message,
     has_shown_update_message,
     reset_active_context,
     reset_to,
     set_active_context,
+    set_has_shown_python_version_message,
     set_has_shown_update_message,
 )
 from layer.logged_data.log_data_runner import LogDataRunner
@@ -572,6 +574,7 @@ def run(functions: List[Any], debug: bool = False) -> Run:
         run = layer.run([create_my_dataset])
         # run = layer.run([create_my_dataset], debug=True)  # Stream logs to console
     """
+    _check_python_version()
     _ensure_all_functions_are_decorated(functions)
 
     layer_config = asyncio_run_in_thread(ConfigManager().refresh())
@@ -665,9 +668,24 @@ def _check_latest_version() -> None:
     current_version = pkg_resources.get_distribution("layer").version
     if current_version != latest_version:
         print(
-            "You are using the version {current_version} but the latest version is {latest_version}, please upgrade with 'pip install --upgrade layer'"
+            f"You are using the version {current_version} but the latest version is {latest_version}, please upgrade with 'pip install --upgrade layer'"
         )
     set_has_shown_update_message(True)
+
+
+def _check_python_version() -> None:
+    if has_shown_python_version_message():
+        return
+
+    import platform
+
+    major, minor, _ = platform.python_version_tuple()
+
+    if major != "3" or minor not in ["7", "8"]:
+        print(
+            f"You are using the Python version {platform.python_version()} but layer requires Python 3.7.x or 3.8.x"
+        )
+    set_has_shown_python_version_message(True)
 
 
 def _ensure_all_functions_are_decorated(functions: List[Callable[..., Any]]) -> None:


### PR DESCRIPTION
Check if the Python version is supported on the first remote call (when users call `layer.run`) since fetching models/dataset or running local builds/trains works in any Python version.