### PR TITLE
Make decorators available on the layer module

### DIFF
--- a/layer/__init__.py
+++ b/layer/__init__.py
@@ -5,6 +5,7 @@ from .contracts.logged_data import Markdown  # noqa
 from .contracts.models import Model  # noqa
 from .contracts.projects import Project  # noqa
 from .contracts.runs import Run  # noqa
+from .decorators import dataset, fabric, model, pip_requirements, resources  # noqa
 from .flavors.custom import CustomModel  # noqa
 from .global_context import current_project_full_name  # noqa
 from .logged_data.callbacks import KerasCallback, XGBoostCallback  # noqa

--- a/layer/clients/model_training_service.py
+++ b/layer/clients/model_training_service.py
@@ -23,7 +23,6 @@ from layerapi.api.service.modeltraining.model_training_api_pb2_grpc import (
 from layerapi.api.value.s3_path_pb2 import S3Path
 
 from layer.config import ClientConfig
-from layer.contracts.runs import FunctionDefinition
 from layer.exceptions.exceptions import LayerClientException
 from layer.utils.file_utils import tar_directory
 from layer.utils.grpc import create_grpc_channel
@@ -57,12 +56,12 @@ class ModelTrainingClient:
             yield self
 
     def upload_training_files(
-        self, model: FunctionDefinition, model_version_id: uuid.UUID
+        self, asset_name: str, function_home_dir: Path, model_version_id: uuid.UUID
     ) -> S3Path:
         response = self.get_source_code_upload_credentials(model_version_id)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            tar_directory(f"{tmp_dir}/{model.asset_name}.tgz", model.function_home_dir)
+            tar_directory(f"{tmp_dir}/{asset_name}.tgz", function_home_dir)
             S3Util.upload_dir(
                 Path(tmp_dir),
                 response.credentials,

--- a/layer/contracts/definitions.py
+++ b/layer/contracts/definitions.py
@@ -1,0 +1,158 @@
+import hashlib
+import inspect
+import os
+import pickle  # nosec import_pickle
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any, Callable, List, Optional
+
+import cloudpickle  # type: ignore
+
+from layer.config import DEFAULT_FUNC_PATH, is_feature_active
+from layer.contracts.assertions import Assertion
+from layer.contracts.asset import AssetPath, AssetType
+from layer.contracts.fabrics import Fabric
+from layer.contracts.project_full_name import ProjectFullName
+from layer.contracts.runs import ResourcePath
+from layer.executables.tar import (
+    DATASET_BUILD_ENTRYPOINT_FILE,
+    MODEL_TRAIN_ENTRYPOINT_FILE,
+    build_executable_tar,
+)
+
+
+class FunctionDefinition:
+    def __init__(
+        self,
+        func: Callable[..., Any],
+        project_name: str,
+        account_name: str,
+        asset_type: AssetType,
+        asset_name: str,
+        fabric: Fabric,
+        asset_dependencies: List[AssetPath],
+        pip_dependencies: List[str],
+        resource_paths: List[ResourcePath],
+        assertions: List[Assertion],
+        version_id: Optional[uuid.UUID] = None,
+        repository_id: Optional[uuid.UUID] = None,
+        description: str = "",
+        uri: str = "",
+    ) -> None:
+        self.func = func
+        self.func_name: str = func.__name__
+
+        self.project_name = project_name
+        self.account_name = account_name
+        self.asset_type = asset_type
+        self.asset_name = asset_name
+        self.fabric = fabric
+        self.asset_dependencies = asset_dependencies
+        self.pip_dependencies = pip_dependencies
+        self.resource_paths = resource_paths
+        self.assertions = assertions
+
+        self.version_id = version_id
+        self.repository_id = repository_id
+        self.description = description
+        self.uri = uri
+
+        self.func_source = inspect.getsource(self.func)
+
+        self.source_code_digest = hashlib.sha256()
+        self.source_code_digest.update(self.func_source.encode("utf-8"))
+
+    def __repr__(self) -> str:
+        return f"FunctionDefinition({self.asset_type}, {self.asset_name})"
+
+    @property
+    def project_full_name(self) -> ProjectFullName:
+        return ProjectFullName(
+            account_name=self.account_name,
+            project_name=self.project_name,
+        )
+
+    @property
+    def asset_path(self) -> AssetPath:
+        return AssetPath(
+            asset_type=self.asset_type,
+            asset_name=self.asset_name,
+            project_name=self.project_name,
+            org_name=self.account_name,
+        )
+
+    @property
+    def function_home_dir(self) -> Path:
+        return DEFAULT_FUNC_PATH / self.asset_path.path()
+
+    def set_version_id(self, version_id: uuid.UUID) -> None:
+        self.version_id = version_id
+
+    def set_repository_id(self, repository_id: uuid.UUID) -> None:
+        self.repository_id = repository_id
+
+    def drop_dependencies(self) -> "FunctionDefinition":
+        self.asset_dependencies = []
+        return self
+
+    # DEPRECATED below, will remove once we build the simplified backend
+    def get_pickled_function(self) -> bytes:
+        return cloudpickle.dumps(self.func, protocol=pickle.DEFAULT_PROTOCOL)
+
+    @property
+    def entrypoint(self) -> str:
+        return f"{self.asset_name}.pkl"
+
+    @property
+    def pickle_path(self) -> Path:
+        return self.function_home_dir / self.entrypoint
+
+    @property
+    def tar_path(self) -> Path:
+        return self.function_home_dir / f"{self.asset_name}.tar"
+
+    @property
+    def environment(self) -> str:
+        return "requirements.txt"
+
+    @property
+    def environment_path(self) -> Path:
+        return self.function_home_dir / self.environment
+
+    def get_fabric(self, is_local: bool) -> str:
+        if is_local:
+            return Fabric.F_LOCAL.value
+        else:
+            return self.fabric.value
+
+    def _clean_function_home_dir(self) -> None:
+        # Remove directory to clean leftovers from previous runs
+        function_home_dir = self.function_home_dir
+        if function_home_dir.exists():
+            shutil.rmtree(function_home_dir)
+        os.makedirs(function_home_dir)
+
+    def package(self) -> None:
+        self._clean_function_home_dir()
+        if is_feature_active("TAR_PACKAGING"):
+            build_executable_tar(
+                path=self.tar_path,
+                function=self.func,
+                entrypoint=MODEL_TRAIN_ENTRYPOINT_FILE
+                if self.asset_type == AssetType.MODEL
+                else DATASET_BUILD_ENTRYPOINT_FILE,
+                pip_dependencies=self.pip_dependencies,
+                resources=[
+                    Path(local_path)
+                    for resource_path in self.resource_paths
+                    for local_path in resource_path.local_relative_paths()
+                ],
+            )
+        else:
+            # Dump pickled function to asset_name.pkl
+            with open(self.pickle_path, mode="wb") as file:
+                cloudpickle.dump(self.func, file, protocol=pickle.DEFAULT_PROTOCOL)
+
+            with open(self.environment_path, "w") as reqs_file:
+                reqs_file.write("\n".join(self.pip_dependencies))

--- a/layer/contracts/runs.py
+++ b/layer/contracts/runs.py
@@ -1,12 +1,11 @@
 import os
-from dataclasses import dataclass, field, replace
-from typing import Callable, Iterator, List, Optional, Sequence
+from dataclasses import dataclass
+from typing import Callable, Iterator, List
 
 from layerapi.api.entity.run_pb2 import Run as PBRun
 from layerapi.api.ids_pb2 import RunId
 
 from layer.contracts.project_full_name import ProjectFullName
-from layer.decorators.definitions import FunctionDefinition
 
 
 GetRunsFunction = Callable[[], List[PBRun]]
@@ -55,11 +54,8 @@ class Run:
 
     """
 
+    id: RunId
     project_full_name: ProjectFullName
-    definitions: Sequence[FunctionDefinition] = field(default_factory=list, repr=False)
-    files_hash: str = ""
-    readme: str = field(repr=False, default="")
-    run_id: Optional[RunId] = field(repr=False, default=None)
 
     @property
     def project_name(self) -> str:
@@ -68,9 +64,3 @@ class Run:
     @property
     def account_name(self) -> str:
         return self.project_full_name.account_name
-
-    def with_run_id(self, run_id: RunId) -> "Run":
-        return replace(self, run_id=run_id)
-
-    def with_definitions(self, definitions: Sequence[FunctionDefinition]) -> "Run":
-        return replace(self, definitions=definitions)

--- a/layer/contracts/runs.py
+++ b/layer/contracts/runs.py
@@ -1,33 +1,12 @@
-import hashlib
-import inspect
 import os
-import pickle  # nosec import_pickle
-import shutil
-import sys
-import uuid
 from dataclasses import dataclass, field, replace
-from pathlib import Path
-from typing import Any, Callable, Iterator, List, Optional, Sequence, Tuple, TypeVar
+from typing import Callable, Iterator, List, Optional, Sequence
 
-import cloudpickle  # type: ignore
 from layerapi.api.entity.run_pb2 import Run as PBRun
 from layerapi.api.ids_pb2 import RunId
 
-from layer.config import DEFAULT_FUNC_PATH, is_feature_active
-from layer.contracts.assertions import Assertion
-from layer.executables.tar import (
-    DATASET_BUILD_ENTRYPOINT_FILE,
-    MODEL_TRAIN_ENTRYPOINT_FILE,
-    build_executable_tar,
-)
-
-from .asset import AssetPath, AssetType
-from .fabrics import Fabric
-from .project_full_name import ProjectFullName
-
-
-def _language_version() -> Tuple[int, int, int]:
-    return sys.version_info.major, sys.version_info.minor, sys.version_info.micro
+from layer.contracts.project_full_name import ProjectFullName
+from layer.decorators.definitions import FunctionDefinition
 
 
 GetRunsFunction = Callable[[], List[PBRun]]
@@ -58,147 +37,6 @@ class ResourcePath:
                 for f in files:
                     dir_file_path = os.path.join(root, f)
                     yield os.path.relpath(dir_file_path)
-
-
-FunctionDefinitionType = TypeVar(  # pylint: disable=invalid-name
-    "FunctionDefinitionType", bound="FunctionDefinition"
-)
-
-
-class FunctionDefinition:
-    def __init__(
-        self,
-        func: Callable[..., Any],
-        project_name: str,
-        account_name: str,
-        asset_type: AssetType,
-        asset_name: str,
-        fabric: Fabric,
-        asset_dependencies: List[AssetPath],
-        pip_dependencies: List[str],
-        resource_paths: List[ResourcePath],
-        assertions: List[Assertion],
-        version_id: Optional[uuid.UUID] = None,
-        repository_id: Optional[uuid.UUID] = None,
-        description: str = "",
-        uri: str = "",
-    ) -> None:
-        self.func = func
-        self.func_name: str = func.__name__
-
-        self.project_name = project_name
-        self.account_name = account_name
-        self.asset_type = asset_type
-        self.asset_name = asset_name
-        self.fabric = fabric
-        self.asset_dependencies = asset_dependencies
-        self.pip_dependencies = pip_dependencies
-        self.resource_paths = resource_paths
-        self.assertions = assertions
-
-        self.version_id = version_id
-        self.repository_id = repository_id
-        self.description = description
-        self.uri = uri
-
-        self.func_source = inspect.getsource(self.func)
-
-        self.source_code_digest = hashlib.sha256()
-        self.source_code_digest.update(self.func_source.encode("utf-8"))
-
-    def __repr__(self) -> str:
-        return f"FunctionDefinition({self.asset_type}, {self.asset_name})"
-
-    @property
-    def project_full_name(self) -> ProjectFullName:
-        return ProjectFullName(
-            account_name=self.account_name,
-            project_name=self.project_name,
-        )
-
-    @property
-    def asset_path(self) -> AssetPath:
-        return AssetPath(
-            asset_type=self.asset_type,
-            asset_name=self.asset_name,
-            project_name=self.project_name,
-            org_name=self.account_name,
-        )
-
-    @property
-    def function_home_dir(self) -> Path:
-        return DEFAULT_FUNC_PATH / self.asset_path.path()
-
-    def set_version_id(self, version_id: uuid.UUID) -> None:
-        self.version_id = version_id
-
-    def set_repository_id(self, repository_id: uuid.UUID) -> None:
-        self.repository_id = repository_id
-
-    def drop_dependencies(self) -> "FunctionDefinition":
-        self.asset_dependencies = []
-        return self
-
-    # DEPRECATED below, will remove once we build the simplified backend
-    def get_pickled_function(self) -> bytes:
-        return cloudpickle.dumps(self.func, protocol=pickle.DEFAULT_PROTOCOL)
-
-    @property
-    def entrypoint(self) -> str:
-        return f"{self.asset_name}.pkl"
-
-    @property
-    def pickle_path(self) -> Path:
-        return self.function_home_dir / self.entrypoint
-
-    @property
-    def tar_path(self) -> Path:
-        return self.function_home_dir / f"{self.asset_name}.tar"
-
-    @property
-    def environment(self) -> str:
-        return "requirements.txt"
-
-    @property
-    def environment_path(self) -> Path:
-        return self.function_home_dir / self.environment
-
-    def get_fabric(self, is_local: bool) -> str:
-        if is_local:
-            return Fabric.F_LOCAL.value
-        else:
-            return self.fabric.value
-
-    def _clean_function_home_dir(self) -> None:
-        # Remove directory to clean leftovers from previous runs
-        function_home_dir = self.function_home_dir
-        if function_home_dir.exists():
-            shutil.rmtree(function_home_dir)
-        os.makedirs(function_home_dir)
-
-    def package(self) -> None:
-        self._clean_function_home_dir()
-        if is_feature_active("TAR_PACKAGING"):
-            build_executable_tar(
-                path=self.tar_path,
-                function=self.func,
-                entrypoint=MODEL_TRAIN_ENTRYPOINT_FILE
-                if self.asset_type == AssetType.MODEL
-                else DATASET_BUILD_ENTRYPOINT_FILE,
-                pip_dependencies=self.pip_dependencies,
-                resources=[
-                    Path(local_path)
-                    for resource_path in self.resource_paths
-                    for local_path in resource_path.local_relative_paths()
-                ],
-            )
-        else:
-            # Dump pickled function to asset_name.pkl
-            with open(self.pickle_path, mode="wb") as file:
-                cloudpickle.dump(self.func, file, protocol=pickle.DEFAULT_PROTOCOL)
-
-            with open(self.environment_path, "w") as reqs_file:
-                reqs_file.write("\n".join(self.pip_dependencies))
 
 
 @dataclass(frozen=True)

--- a/layer/decorators/definitions.py
+++ b/layer/decorators/definitions.py
@@ -1,1 +1,0 @@
-from layer.contracts.runs import FunctionDefinition  # noqa

--- a/layer/decorators/layer_wrapper.py
+++ b/layer/decorators/layer_wrapper.py
@@ -4,9 +4,9 @@ import wrapt  # type: ignore
 
 from layer.contracts.assets import AssetPath, AssetType, BaseAsset
 from layer.contracts.datasets import Dataset
+from layer.contracts.definitions import FunctionDefinition
 from layer.contracts.models import Model
 from layer.contracts.project_full_name import ProjectFullName
-from layer.contracts.runs import FunctionDefinition
 from layer.projects.utils import get_current_project_full_name
 from layer.settings import LayerSettings
 

--- a/layer/executables/tar.py
+++ b/layer/executables/tar.py
@@ -96,8 +96,8 @@ tail -n+$ARCHIVE $0 | tar xz -C $TMPDIR
 cd $TMPDIR
 $PYTHON_EXECUTABLE_PATH -m venv --system-site-packages venv
 . ./venv/bin/activate
-python -m pip install -r requirements.txt
-python entrypoint.py
+$PYTHON_EXECUTABLE_PATH -m pip install -r requirements.txt
+$PYTHON_EXECUTABLE_PATH entrypoint.py
 
 exit 0
 

--- a/layer/main.py
+++ b/layer/main.py
@@ -579,12 +579,15 @@ def run(functions: List[Any], debug: bool = False) -> Run:
     _check_python_version()
     _ensure_all_functions_are_decorated(functions)
 
-    layer_config = asyncio_run_in_thread(ConfigManager().refresh())
+    layer_config: Config = asyncio_run_in_thread(ConfigManager().refresh())
 
     project_full_name = get_current_project_full_name()
-    project_runner = ProjectRunner(config=layer_config)
-    run = project_runner.with_functions(project_full_name, functions)
-    run = project_runner.run(run, debug=debug)
+    project_runner = ProjectRunner(
+        config=layer_config,
+        project_full_name=project_full_name,
+        functions=functions,
+    )
+    run = project_runner.run(debug=debug)
 
     _make_notebook_links_open_in_new_tab()
 

--- a/layer/projects/execution_planner.py
+++ b/layer/projects/execution_planner.py
@@ -14,7 +14,7 @@ from layerapi.api.entity.operations_pb2 import (
 from layerapi.api.ids_pb2 import ModelVersionId
 
 from layer.contracts.assets import AssetPath, AssetType
-from layer.contracts.runs import FunctionDefinition, Run
+from layer.contracts.definitions import FunctionDefinition
 from layer.exceptions.exceptions import (
     LayerClientException,
     ProjectCircularDependenciesException,
@@ -34,8 +34,8 @@ class PlanNode:
     id: Optional[uuid.UUID]
 
 
-def build_execution_plan(run: Run) -> ExecutionPlan:
-    graph = _build_directed_acyclic_graph(run.definitions)
+def build_execution_plan(definitions: Sequence[FunctionDefinition]) -> ExecutionPlan:
+    graph = _build_directed_acyclic_graph(definitions)
     plan = _topological_sort_grouping(graph)
     operations = []
     for _level, ops in plan.items():

--- a/layer/projects/progress_tracker_updater.py
+++ b/layer/projects/progress_tracker_updater.py
@@ -9,6 +9,7 @@ from layerapi.api.entity.task_pb2 import Task as PBTask
 from layerapi.api.ids_pb2 import ModelTrainId, ModelVersionId
 
 from layer.clients.layer import LayerClient
+from layer.contracts.definitions import FunctionDefinition
 from layer.contracts.projects import ApplyResult
 from layer.contracts.runs import Run
 from layer.exceptions.exceptions import (
@@ -41,6 +42,7 @@ class ProgressTrackerUpdater:
     client: LayerClient
     apply_metadata: ApplyResult
     run: Run
+    definitions: List[FunctionDefinition]
     run_metadata: _FormattedRunMetadata
 
     def __init__(
@@ -48,11 +50,13 @@ class ProgressTrackerUpdater:
         tracker: RunProgressTracker,
         apply_metadata: ApplyResult,
         run: Run,
+        definitions: List[FunctionDefinition],
         client: LayerClient,
     ):
         self.tracker = tracker
         self.apply_metadata = apply_metadata
         self.run = run
+        self.definitions = definitions
         self.client = client
 
     @staticmethod
@@ -83,10 +87,10 @@ class ProgressTrackerUpdater:
             if event_type == "run":
                 run_status = event.run.run_status
                 if run_status == PBRun.STATUS_TERMINATED:
-                    raise ProjectRunTerminatedError(run_id=self.run.run_id)
+                    raise ProjectRunTerminatedError(run_id=self.run.id)
 
                 elif run_status == PBRun.STATUS_FAILED:
-                    raise ProjectRunnerError("Run failed", self.run.run_id)
+                    raise ProjectRunnerError("Run failed", self.run.id)
 
                 elif run_status in [PBRun.STATUS_SUCCEEDED]:
                     return True
@@ -160,13 +164,13 @@ class ProgressTrackerUpdater:
             _print_debug(f"Task type not handled {task_type}")
 
     def _handle_task_failed(self, task: PBTask) -> None:
-        assert self.run.run_id
+        assert self.run.id
         task_id = task.id
         task_type = task.type
         task_info = task.info
         if task_type == PBTask.TYPE_DATASET_BUILD:
             exc_ds = ProjectDatasetBuildExecutionException(
-                self.run.run_id,
+                self.run.id,
                 task_id,
                 ExecutionStatusReportFactory.from_json(task_info),
             )
@@ -174,7 +178,7 @@ class ProgressTrackerUpdater:
             raise exc_ds
         elif task_type == PBTask.TYPE_MODEL_TRAIN:
             exc_model = ProjectModelExecutionException(
-                self.run.run_id,
+                self.run.id,
                 task_id,
                 ExecutionStatusReportFactory.from_json(task_info),
             )
@@ -201,7 +205,7 @@ class ProgressTrackerUpdater:
             _print_debug(f"Task type not handled {task_type}")
 
     def _find_model_name_by_version_id(self, version_id: str) -> str:
-        for definition in self.run.definitions:
+        for definition in self.definitions:
             if str(definition.version_id) == version_id:
                 return definition.asset_name
         raise KeyError(version_id)

--- a/layer/projects/project_runner.py
+++ b/layer/projects/project_runner.py
@@ -11,9 +11,10 @@ from layerapi.api.ids_pb2 import RunId
 from layer.clients.layer import LayerClient
 from layer.config import Config
 from layer.contracts.assets import AssetType
+from layer.contracts.definitions import FunctionDefinition
 from layer.contracts.project_full_name import ProjectFullName
 from layer.contracts.projects import ApplyResult
-from layer.contracts.runs import FunctionDefinition, Run
+from layer.contracts.runs import Run
 from layer.exceptions.exceptions import (
     LayerClientException,
     LayerClientServiceUnavailableException,
@@ -84,63 +85,52 @@ class ProjectRunner:
     def __init__(
         self,
         config: Config,
+        project_full_name: ProjectFullName,
+        functions: List[Any],
     ) -> None:
         self._config = config
+        self.project_full_name = project_full_name
+        self.definitions: List[FunctionDefinition] = [
+            f.get_definition() for f in functions
+        ]
+        self.files_hash = calculate_hash_by_definitions(self.definitions)
 
     def get_tracker(self) -> RunProgressTracker:
         return self._tracker
 
-    def _apply(self, client: LayerClient, run: Run) -> ApplyResult:
-        for definition in run.definitions:
+    def _apply(self, client: LayerClient) -> ApplyResult:
+        for definition in self.definitions:
             if definition.asset_type == AssetType.DATASET:
                 register_dataset_function(client, definition, False, self._tracker)
-            if definition.asset_type == AssetType.MODEL:
+            elif definition.asset_type == AssetType.MODEL:
                 register_model_function(client, definition, False, self._tracker)
 
-        execution_plan = build_execution_plan(run)
-        client.project_service_client.update_project_readme(
-            run.project_full_name, run.readme
-        )
+        execution_plan = build_execution_plan(self.definitions)
         return ApplyResult(execution_plan=execution_plan)
 
-    @staticmethod
-    def with_functions(project_full_name: ProjectFullName, functions: List[Any]) -> Run:
-        definitions: List[FunctionDefinition] = [f.get_definition() for f in functions]
-
-        return Run(
-            project_full_name=project_full_name,
-            definitions=definitions,
-            files_hash=calculate_hash_by_definitions(definitions),
-        )
-
-    def run(
-        self,
-        run: Run,
-        debug: bool = False,
-        printer: Callable[[str], Any] = print,
-    ) -> Run:
-        check_asset_dependencies(run.definitions)
-        for definition in run.definitions:
+    def run(self, debug: bool = False, printer: Callable[[str], Any] = print) -> Run:
+        check_asset_dependencies(self.definitions)
+        for definition in self.definitions:
             definition.package()
         with LayerClient(self._config.client, logger).init() as client:
-            get_or_create_remote_project(client, run.project_full_name)
+            get_or_create_remote_project(client, self.project_full_name)
             with RunProgressTracker(
                 url=self._config.url,
-                account_name=run.project_full_name.account_name,
-                project_name=run.project_full_name.project_name,
-                assets=[(d.asset_type, d.asset_name) for d in run.definitions],
+                account_name=self.project_full_name.account_name,
+                project_name=self.project_full_name.project_name,
+                assets=[(d.asset_type, d.asset_name) for d in self.definitions],
             ).track() as tracker:
                 self._tracker = tracker
                 try:
-                    metadata = self._apply(client, run)
-                    ResourceManager(client).wait_resource_upload(run, tracker)
+                    metadata = self._apply(client)
+                    ResourceManager(client).wait_resource_upload(
+                        self.project_full_name, self.definitions, tracker
+                    )
                     user_command = self._get_user_command(
-                        execute_function=ProjectRunner.run, functions=run.definitions
+                        execute_function=ProjectRunner.run, functions=self.definitions
                     )
-                    run_id = self._run(
-                        client, run, metadata.execution_plan, user_command
-                    )
-                    run = run.with_run_id(run_id)
+                    run_id = self._run(client, metadata.execution_plan, user_command)
+                    run = Run(id=run_id, project_full_name=self.project_full_name)
                 except LayerClientServiceUnavailableException as e:
                     raise LayerServiceUnavailableExceptionDuringInitialization(str(e))
                 try:
@@ -168,7 +158,6 @@ class ProjectRunner:
                     raise LayerServiceUnavailableExceptionDuringExecution(
                         run_id, str(e)
                     )
-
         return run
 
     @staticmethod
@@ -193,16 +182,16 @@ class ProjectRunner:
             tracker=self._tracker,
             apply_metadata=apply_metadata,
             run=run,
+            definitions=self.definitions,
             client=client,
         )
 
         initial_step_sec = 2
         step_function = PollingStepFunction(max_backoff_sec=3.0, backoff_multiplier=1.2)
 
-        assert run.run_id
         polling.poll(
             lambda: client.flow_manager.get_run_status_history_and_metadata(
-                run_id=run.run_id,
+                run_id=run.id,
             ),
             check_success=updater.check_completion_and_update_tracker,
             step=initial_step_sec,
@@ -211,16 +200,18 @@ class ProjectRunner:
             poll_forever=True,
         )
 
-    @staticmethod
     def _run(
+        self,
         client: LayerClient,
-        run: Run,
         execution_plan: ExecutionPlan,
         user_command: str,
     ) -> RunId:
         try:
             run_id = client.flow_manager.start_run(
-                run.project_full_name, execution_plan, run.files_hash, user_command
+                self.project_full_name,
+                execution_plan,
+                self.files_hash,
+                user_command,
             )
         except LayerResourceExhaustedException as e:
             raise ProjectRunnerError(f"{e}")
@@ -243,7 +234,16 @@ def register_dataset_function(
         project_id = verify_project_exists_and_retrieve_project_id(
             client, dataset.project_full_name
         )
-        dataset_id = client.data_catalog.add_dataset(project_id, dataset, is_local)
+        dataset_id = client.data_catalog.add_dataset(
+            dataset.asset_path,
+            project_id,
+            dataset.description,
+            dataset.function_home_dir,
+            dataset.get_fabric(is_local),
+            dataset.func_source,
+            dataset.entrypoint,
+            dataset.environment,
+        )
         dataset.set_repository_id(uuid.UUID(dataset_id))
         assert dataset.repository_id
         tracker.mark_dataset_saved(dataset.asset_name, id_=dataset.repository_id)
@@ -266,16 +266,30 @@ def register_model_function(
 ) -> None:
     try:
         response = client.model_catalog.create_model_version(
-            model.project_full_name, model, is_local
+            model.asset_path,
+            model.description,
+            model.source_code_digest.hexdigest(),
+            model.get_fabric(is_local),
         )
         version = response.model_version
         model.set_version_id(version.id.value)
         if response.should_upload_training_files:
             # in here we upload to path / train.gz
             version_id = uuid.UUID(version.id.value)
-            s3_path = client.model_training.upload_training_files(model, version_id)
+            s3_path = client.model_training.upload_training_files(
+                model.asset_name, model.function_home_dir, version_id
+            )
             # in here we reconstruct the path / train.gz to save in metadata
-            client.model_catalog.store_training_metadata(model, s3_path, version)
+            client.model_catalog.store_training_metadata(
+                model.asset_name,
+                model.description,
+                model.entrypoint,
+                model.environment,
+                s3_path,
+                version,
+                model.get_fabric(is_local),
+            )
+
         tracker.mark_model_saved(model.asset_name)
     except LayerClientServiceUnavailableException as e:
         tracker.mark_model_train_failed(model.asset_name, "")

--- a/layer/projects/utils.py
+++ b/layer/projects/utils.py
@@ -3,9 +3,9 @@ from typing import List
 from uuid import UUID
 
 from layer.clients.layer import LayerClient
+from layer.contracts.definitions import FunctionDefinition
 from layer.contracts.project_full_name import ProjectFullName
 from layer.contracts.projects import Project
-from layer.contracts.runs import FunctionDefinition
 from layer.exceptions.exceptions import ProjectInitializationException
 from layer.global_context import current_project_full_name
 

--- a/test/e2e/test_dataset_column_types.py
+++ b/test/e2e/test_dataset_column_types.py
@@ -114,7 +114,7 @@ def test_remote_run_with_supported_column_types_succeeds_and_registers_metadata(
     run = layer.run([prepare_data])
 
     # then
-    asserter.assert_run_succeeded(run.run_id)
+    asserter.assert_run_succeeded(run.id)
 
     types_ds = layer.get_dataset(dataset_name)
     types_pandas = types_ds.to_pandas()

--- a/test/e2e/test_function_assertion_run.py
+++ b/test/e2e/test_function_assertion_run.py
@@ -49,7 +49,7 @@ def test_remote_run_succeeds_and_registers_metadata_when_assertion_succeeds(
     run = layer.run([prepare_data])
 
     # then
-    asserter.assert_run_succeeded(run.run_id)
+    asserter.assert_run_succeeded(run.id)
     ds = layer.get_dataset(dataset_name)
     assert len(ds.to_pandas().index) == 10
 

--- a/test/e2e/test_function_dataset_run.py
+++ b/test/e2e/test_function_dataset_run.py
@@ -49,7 +49,7 @@ def test_remote_run_with_dependent_datasets_succeeds_and_registers_metadata(
     run = layer.run([prepare_data, transform_data])
 
     # then
-    asserter.assert_run_succeeded(run.run_id)
+    asserter.assert_run_succeeded(run.id)
 
     first_ds = layer.get_dataset(dataset_name)
     first_pandas = first_ds.to_pandas()

--- a/test/e2e/test_function_model_run.py
+++ b/test/e2e/test_function_model_run.py
@@ -28,7 +28,7 @@ def test_remote_run_succeeds_and_registers_metadata(
     run = layer.run([train_model])
 
     # then
-    asserter.assert_run_succeeded(run.run_id)
+    asserter.assert_run_succeeded(run.id)
     mdl = layer.get_model(model_name)
     assert isinstance(mdl.get_train(), SVC)
 

--- a/test/e2e/test_log_types.py
+++ b/test/e2e/test_log_types.py
@@ -33,7 +33,7 @@ def test_scalar_values_logged(
     run = layer.run([scalar])
 
     # then
-    asserter.assert_run_succeeded(run.run_id)
+    asserter.assert_run_succeeded(run.id)
 
     first_ds = client.data_catalog.get_dataset_by_name(
         initialized_project.id, dataset_name

--- a/test/e2e/test_pandas_images_dataset.py
+++ b/test/e2e/test_pandas_images_dataset.py
@@ -27,7 +27,7 @@ def test_pandas_images_dataset_store_and_save(
         )
 
     run = layer.run([build_images])
-    asserter.assert_run_succeeded(run.run_id)
+    asserter.assert_run_succeeded(run.id)
 
     data = layer.get_dataset(f"{initialized_project.name}/datasets/images").to_pandas()
 

--- a/test/unit/decorators/test_dataset_decorator.py
+++ b/test/unit/decorators/test_dataset_decorator.py
@@ -12,10 +12,10 @@ from layerapi.api.service.datacatalog.data_catalog_api_pb2 import InitiateBuildR
 from layer.clients.data_catalog import DataCatalogClient
 from layer.contracts.assets import AssetType
 from layer.contracts.datasets import Dataset
+from layer.contracts.definitions import FunctionDefinition
 from layer.contracts.fabrics import Fabric
 from layer.contracts.models import Model
 from layer.contracts.project_full_name import ProjectFullName
-from layer.contracts.runs import FunctionDefinition
 from layer.decorators import dataset, fabric, pip_requirements
 from layer.exceptions.exceptions import (
     ConfigError,

--- a/test/unit/decorators/test_model_decorator.py
+++ b/test/unit/decorators/test_model_decorator.py
@@ -6,7 +6,7 @@ import pytest
 
 from layer import Dataset, Model
 from layer.contracts.assets import AssetType
-from layer.contracts.runs import FunctionDefinition
+from layer.contracts.definitions import FunctionDefinition
 from layer.decorators.model_decorator import model
 from layer.decorators.pip_requirements_decorator import pip_requirements
 from layer.exceptions.exceptions import ProjectInitializationException

--- a/test/unit/projects/test_execution_planner.py
+++ b/test/unit/projects/test_execution_planner.py
@@ -5,10 +5,9 @@ import pytest
 
 from layer.contracts.asset import AssetType
 from layer.contracts.assets import AssetPath
+from layer.contracts.definitions import FunctionDefinition
 from layer.contracts.fabrics import Fabric
 from layer.contracts.project_full_name import ProjectFullName
-from layer.contracts.runs import Run
-from layer.decorators.definitions import FunctionDefinition
 from layer.exceptions.exceptions import ProjectCircularDependenciesException
 from layer.projects.execution_planner import (
     _build_graph,
@@ -114,9 +113,7 @@ class TestProjectExecutionPlanner:
     def test_build_execution_plan_linear(self) -> None:
         definitions = self._create_mock_run_linear()
 
-        execution_plan = build_execution_plan(
-            Run(TEST_PROJECT_FULL_NAME, definitions=definitions)
-        )
+        execution_plan = build_execution_plan(definitions)
         assert execution_plan is not None
         ops = execution_plan.operations
 
@@ -143,9 +140,7 @@ class TestProjectExecutionPlanner:
     def test_build_execution_plan_parallel(self) -> None:
         definitions = self._create_mock_run_parallel()
 
-        execution_plan = build_execution_plan(
-            Run(TEST_PROJECT_FULL_NAME, definitions=definitions)
-        )
+        execution_plan = build_execution_plan(definitions)
         assert execution_plan is not None
         ops = execution_plan.operations
 
@@ -155,9 +150,7 @@ class TestProjectExecutionPlanner:
 
     def test_build_execution_plan_mixed(self) -> None:
         definitions = self._create_mock_run_mixed()
-        execution_plan = build_execution_plan(
-            Run(TEST_PROJECT_FULL_NAME, definitions=definitions)
-        )
+        execution_plan = build_execution_plan(definitions)
         assert execution_plan is not None
         ops = execution_plan.operations
 
@@ -171,9 +164,7 @@ class TestProjectExecutionPlanner:
             AssetPath.parse(f"{TEST_PROJECT_FULL_NAME.path}/datasets/ds2"),
             keep_dependencies=False,
         )
-        execution_plan = build_execution_plan(
-            Run(TEST_PROJECT_FULL_NAME, definitions=definitions2)
-        )
+        execution_plan = build_execution_plan(definitions2)
 
         assert execution_plan is not None
         ops = execution_plan.operations

--- a/test/unit/projects/test_project_hash_calculator.py
+++ b/test/unit/projects/test_project_hash_calculator.py
@@ -3,9 +3,9 @@ from typing import Any, Callable
 import pandas
 
 from layer.contracts.asset import AssetType
+from layer.contracts.definitions import FunctionDefinition
 from layer.contracts.fabrics import Fabric
 from layer.decorators import model
-from layer.decorators.definitions import FunctionDefinition
 from layer.projects.utils import calculate_hash_by_definitions
 
 

--- a/test/unit/projects/test_project_hash_calculator.py
+++ b/test/unit/projects/test_project_hash_calculator.py
@@ -18,12 +18,8 @@ def test_given_same_function_when_hash_calculated_then_hash_equal():
     def func2():
         return pandas.DataFrame({})
 
-    def_1 = _make_test_function_definition(
-        func=func1, project_name="project-name", account_name="acc-name"
-    )
-    def_2 = _make_test_function_definition(
-        func=func1, project_name="project-name", account_name="acc-name"
-    )
+    def_1 = _make_test_function_definition(func=func1)
+    def_2 = _make_test_function_definition(func=func1)
 
     # when
     first_hash = calculate_hash_by_definitions([def_1, def_1])
@@ -46,12 +42,8 @@ def test_given_different_function_when_hash_calculated_then_hash_different():
     def func3():
         return pandas.DataFrame({})
 
-    def_1 = _make_test_function_definition(
-        func=func1, project_name="project-name", account_name="acc-name"
-    )
-    def_2 = _make_test_function_definition(
-        func=func2, project_name="project-name", account_name="acc-name"
-    )
+    def_1 = _make_test_function_definition(func=func1)
+    def_2 = _make_test_function_definition(func=func2)
 
     # when
     first_hash = calculate_hash_by_definitions([def_1, def_1])
@@ -62,7 +54,9 @@ def test_given_different_function_when_hash_calculated_then_hash_different():
 
 
 def _make_test_function_definition(
-    func: Callable[..., Any], project_name: str, account_name: str
+    func: Callable[..., Any],
+    project_name: str = "project-name",
+    account_name: str = "acc-name",
 ) -> FunctionDefinition:
     return FunctionDefinition(
         func=func,

--- a/test/unit/test_run.py
+++ b/test/unit/test_run.py
@@ -15,7 +15,7 @@ from layerapi.api.service.flowmanager.flow_manager_api_pb2 import (
     StartRunV2Response,
 )
 
-from layer.contracts.runs import FunctionDefinition
+from layer.contracts.definitions import FunctionDefinition
 from layer.exceptions.exceptions import ProjectRunnerError
 from layer.projects.project_runner import ProjectRunner
 from layer.utils.grpc.interceptors import (
@@ -29,6 +29,7 @@ from layer.utils.session import (
     is_layer_debug_on,
 )
 from test.unit.grpc_test_utils import new_client_call_details, rpc_error
+from test.unit.projects.test_execution_planner import TEST_PROJECT_FULL_NAME
 
 
 class TestLayerDebug:
@@ -188,6 +189,8 @@ class TestProjectRun:
     def test_project_run_fails_when_max_active_run_exceeds(self) -> None:
         runner = ProjectRunner(
             config=MagicMock(),
+            project_full_name=TEST_PROJECT_FULL_NAME,
+            functions=[],
         )
         error = rpc_error(
             metadata=(),
@@ -199,12 +202,9 @@ class TestProjectRun:
 
         client = MagicMock()
         client.flow_manager.start_run.side_effect = layer_client_exception
-        run = MagicMock()
-        run.project_name.return_value = "test"
         with pytest.raises(ProjectRunnerError, match=".*RESOURCE_EXHAUSTED.*"):
             runner._run(  # pylint: disable=protected-access
                 client=client,
-                run=run,
                 execution_plan=ExecutionPlan(),
                 user_command="",
             )
@@ -212,6 +212,8 @@ class TestProjectRun:
     def test_get_user_command_returns_the_command_correctly(self) -> None:
         runner = ProjectRunner(
             config=MagicMock(),
+            project_full_name=TEST_PROJECT_FULL_NAME,
+            functions=[],
         )
 
         func1: FunctionDefinition = MagicMock()


### PR DESCRIPTION
This PR makes decorators available on the `layer` module, so that they can be used simply with `@layer.dataset` or `@layer.model` without importing them individually. This required a refactor of function definitions to fix circular imports.

This PR is one of several to split https://github.com/layerai/sdk/pull/127 up. This PR should merge after https://github.com/layerai/sdk/pull/137 and https://github.com/layerai/sdk/pull/143 are merged.