### PR TITLE
Ensure we only generated the logs path once per session

### DIFF
--- a/layer/config/config.py
+++ b/layer/config/config.py
@@ -105,7 +105,7 @@ class ClientConfig:
     grpc_gateway_address: str = ""
     access_token: str = ""
     grpc_do_verify_ssl: bool = True
-    logs_file_path: Path = _default_logs_file_path()
+    logs_file_path: Path = LogsConfig().logs_file_path
     s3: S3Config = S3Config.create_default()
 
     def with_access_token(self, access_token: str) -> "ClientConfig":


### PR DESCRIPTION
`ClientConfig` and `LogsConfig` both independently generate a randomized logs path. However `LogRpcCallsInterceptor` does not like the logs path changing during the session which results in the following error:

```
    def __new__(cls, logs_file_path: Path) -> Any:
        if cls._instance is None:
            import atexit
    
            cls._instance = super(LogRpcCallsInterceptor, cls).__new__(cls)
            atexit.register(cls._instance.close)
    
            user_session_id = str(UserSessionId())
            cls._instance._user_session_id = user_session_id  # type: ignore
            cls.should_obfuscate_responses = not is_layer_debug_on()
            cls._instance._logs_file_path = logs_file_path  # type: ignore
            logs_file_path.parent.mkdir(parents=True, exist_ok=True)
            cls._instance._log_file = open(logs_file_path, "w")  # type: ignore
        elif logs_file_path != cls._instance._logs_file_path:  # type: ignore
>           raise ValueError(
                "LogRpcCallsInterceptor instance already exists with different file path"
            )
E           ValueError: LogRpcCallsInterceptor instance already exists with different file path
```

Fix this by using `LogsConfig` inside `ClientConfig` to ensure the path is generated only once.