### PR TITLE
Read version from pyproject.toml to avoid using pkg_resources

### DIFF
--- a/layer/__init__.py
+++ b/layer/__init__.py
@@ -10,6 +10,7 @@ from .logged_data.callbacks import KerasCallback, XGBoostCallback  # noqa
 from .main import clear_cache  # noqa
 from .main import get_dataset  # noqa
 from .main import get_model  # noqa
+from .main import get_version  # noqa
 from .main import init  # noqa
 from .main import log  # noqa
 from .main import login  # noqa
@@ -23,3 +24,5 @@ from .pandas_extensions import Arrays, Images, _register_type_extensions  # noqa
 
 
 _register_type_extensions()
+
+__version__ = get_version()

--- a/layer/main.py
+++ b/layer/main.py
@@ -1,4 +1,6 @@
 import logging
+import pathlib
+import re
 import warnings
 from contextlib import contextmanager
 from pathlib import Path
@@ -662,10 +664,9 @@ def _check_latest_version() -> None:
         return
 
     import luddite  # type: ignore
-    import pkg_resources
 
     latest_version = luddite.get_version_pypi("layer")
-    current_version = pkg_resources.get_distribution("layer").version
+    current_version = get_version()
     if current_version != latest_version:
         print(
             f"You are using the version {current_version} but the latest version is {latest_version}, please upgrade with 'pip install --upgrade layer'"
@@ -841,3 +842,14 @@ def clear_cache() -> None:
     but subsequent calls will read it from the local disk.
     """
     Cache().clear()
+
+
+def get_version() -> str:
+    with open(pathlib.Path(__file__).parent.parent / "pyproject.toml") as pyproject:
+        text = pyproject.read()
+        # Use a simple regex to avoid a dependency on toml
+        version_match = re.search(r'version = "(\d+\.\d+\.\d+)"', text)
+
+    if version_match is None:
+        raise RuntimeError("Failed to parse version")
+    return version_match.group(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ classifiers = [
 ]
 packages = [
     { include = "layer" },
+    { include = "pyproject.toml"}
 ]
 
 [tool.poetry.urls]


### PR DESCRIPTION
Calling `pkg_resources.get_distribution` inside Colab fails hard in the cases where we've upgraded packages without restarting the runtime.

We should fix the package conflicts it complains about as these are real, but for now avoid using it to unblock users.

Instead we add `pyproject.toml` to the package and get the version from there. 