### PR TITLE
Don't use luddite

### DIFF
--- a/layer/main.py
+++ b/layer/main.py
@@ -1,6 +1,8 @@
+import json
 import logging
 import pathlib
 import re
+import urllib.request
 import warnings
 from contextlib import contextmanager
 from pathlib import Path
@@ -659,13 +661,19 @@ document.querySelectorAll(".output a").forEach(function(a){
         )
 
 
+def _get_latest_version() -> str:
+    pypi_url = "https://pypi.org/pypi/layer/json"
+    response = urllib.request.urlopen(pypi_url).read().decode()  # nosec urllib_urlopen
+    data = json.loads(response)
+
+    return data["info"]["version"]
+
+
 def _check_latest_version() -> None:
     if has_shown_update_message():
         return
 
-    import luddite  # type: ignore
-
-    latest_version = luddite.get_version_pypi("layer")
+    latest_version = _get_latest_version()
     current_version = get_version()
     if current_version != latest_version:
         print(

--- a/poetry.lock
+++ b/poetry.lock
@@ -1312,20 +1312,6 @@ scipy = "*"
 dask = ["dask[array] (>=2.0.0)", "dask[dataframe] (>=2.0.0)", "dask[distributed] (>=2.0.0)", "pandas"]
 
 [[package]]
-name = "luddite"
-version = "1.0.2"
-description = "Checks for out-of-date package versions"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[package.extras]
-dev = ["pytest (>=3.6.3)", "pytest-cov", "pytest-mock", "pytest-socket", "coveralls"]
-
-[[package]]
 name = "mako"
 version = "1.2.0"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
@@ -2867,7 +2853,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.11"
-content-hash = "dffc5e3c1e73d10c7fad2ba960021419ef4a46171dc1d72f7c86fb778c92b5f1"
+content-hash = "35c5248f974f2e426d783514dfde439e82c74f36b4ab91cdc5b95b21188a46ea"
 
 [metadata.files]
 absl-py = [
@@ -3654,10 +3640,6 @@ lightgbm = [
     {file = "lightgbm-3.3.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8e788c56853316fc5d35db726d81bd002c721038c856853952287f68082e0158"},
     {file = "lightgbm-3.3.2-py3-none-win_amd64.whl", hash = "sha256:e4f1529cad416066964f9af0efad208787861e9f2181b7f9ee7fc9bacc082d4f"},
     {file = "lightgbm-3.3.2.tar.gz", hash = "sha256:5d25d16e77c844c297ece2044df57651139bc3c8ad8c4108916374267ac68b64"},
-]
-luddite = [
-    {file = "luddite-1.0.2-py2.py3-none-any.whl", hash = "sha256:5d4cd45c91e7876465330b84e18e6994d44b77ee8f723fdc384d5fd7ff160c04"},
-    {file = "luddite-1.0.2.tar.gz", hash = "sha256:8bec9f75247716320da307ff84df141b57fbd1f7e81a8bc2a7d7db88531cebc5"},
 ]
 mako = [
     {file = "Mako-1.2.0-py3-none-any.whl", hash = "sha256:23aab11fdbbb0f1051b93793a58323ff937e98e34aece1c4219675122e57e4ba"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ humanize  = ">=3.11.0"
 idna = "<3"
 mlflow  = ">=1.25.0"
 docker = "^4" # comes from mlflow, docker v5 brings a vulnerable version of pywin32 which is strictly pinned
-luddite = "1.0.2"
 networkx  = ">=2.5"
 pandas = "1.3.5"
 pickle5 = { version = "~0.0.11", python = "<3.8" }


### PR DESCRIPTION
It uses `pkg_resources` under the hood which fails hard when we upgrade a dependency on Colab without restarting the runtime.

Instead just query PyPi directly since this is quite a trivial request and a payload to parse.