### PR TITLE
Ensure IS_DARWIN evaluates to false on Linux

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,7 +2,7 @@ import platform
 
 
 def _is_darwin():
-    return (platform.system() == "Darwin",)
+    return platform.system() == "Darwin"
 
 
 def _is_darwin_arm64():


### PR DESCRIPTION
`IS_DARWIN` returns a tuple which casts to `True` always and hence skips the tests in CI as well as local Linux.

Instead return a boolean.