### PR TITLE
Disable lockfile checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,7 @@ jobs:
 
   check-lockfile:
     runs-on: ubuntu-18.04
+    if: ${{ false }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,7 @@ jobs:
           key: poetry-venvs-${{ runner.os }}-3.8-${{ hashFiles('poetry.lock') }}
           restore-keys: poetry-venvs-${{ runner.os }}-3.8-
       - name: Check lockfile
+        if: ${{ false }}
         run: |
           make install
           poetry lock --no-update


### PR DESCRIPTION
Potentially related to https://github.com/python-poetry/poetry/issues/5967 , we are seeing unstable results when running `poetry lock --no-update`.

To unblock CI, disable this check for now until we get to the bottom of it.