### PR TITLE
Refactor function registration into generic function

### DIFF
--- a/layer/decorators/dataset_decorator.py
+++ b/layer/decorators/dataset_decorator.py
@@ -17,7 +17,7 @@ from layer.contracts.definitions import FunctionDefinition
 from layer.contracts.tracker import DatasetTransferState
 from layer.decorators.layer_wrapper import LayerAssetFunctionWrapper
 from layer.global_context import reset_active_context, set_active_context
-from layer.projects.project_runner import register_dataset_function
+from layer.projects.project_runner import register_function
 from layer.projects.utils import (
     get_current_project_full_name,
     verify_project_exists_and_retrieve_project_id,
@@ -198,7 +198,7 @@ def _build_dataset_locally_and_store_remotely(
 ) -> Any:
     tracker.add_asset(AssetType.DATASET, layer.get_asset_name())
 
-    register_dataset_function(client, dataset, True, tracker)
+    register_function(client, func=dataset, tracker=tracker)
     tracker.mark_dataset_building(layer.get_asset_name())
 
     (result, build_uuid) = _build_locally_update_remotely(

--- a/layer/executables/dataset/entrypoint.py
+++ b/layer/executables/dataset/entrypoint.py
@@ -21,7 +21,7 @@ from layer.global_context import (
     set_active_context,
     set_has_shown_update_message,
 )
-from layer.projects.project_runner import register_dataset_function
+from layer.projects.project_runner import register_function
 from layer.projects.utils import (
     get_current_project_full_name,
     verify_project_exists_and_retrieve_project_id,
@@ -84,7 +84,7 @@ def _run(user_function: Any) -> None:
                 assertions=settings.get_assertions(),
             )
 
-            register_dataset_function(client, dataset, True, tracker)
+            register_function(client, func=dataset, tracker=tracker)
             tracker.mark_dataset_building(settings.get_asset_name())
 
             try:


### PR DESCRIPTION
Extract dataset and model function registrations into single `register_function` function. Make `register_dataset_function` and `register_model_function` "private", to deprecate their use in SDK. This is a step towards function runtime unification.