### PR TITLE
Fix asset statuses in sdk notebook UI 

### DIFF
--- a/layer/projects/progress_tracker_updater.py
+++ b/layer/projects/progress_tracker_updater.py
@@ -154,13 +154,10 @@ class ProgressTrackerUpdater:
             version_name = self.client.model_catalog.get_model_version(
                 ModelVersionId(value=str(task_id))
             ).name
-            self.tracker.mark_model_trained(
+            self.tracker.mark_model_saved(
                 name=model_name,
                 train_index=str(train_index),
                 version=version_name,
-            )
-            self.tracker.mark_model_saved(
-                name=model_name,
             )
         else:
             # TODO: alert for this

--- a/layer/projects/progress_tracker_updater.py
+++ b/layer/projects/progress_tracker_updater.py
@@ -159,6 +159,9 @@ class ProgressTrackerUpdater:
                 train_index=str(train_index),
                 version=version_name,
             )
+            self.tracker.mark_model_saved(
+                name=model_name,
+            )
         else:
             # TODO: alert for this
             _print_debug(f"Task type not handled {task_type}")

--- a/layer/projects/project_runner.py
+++ b/layer/projects/project_runner.py
@@ -314,7 +314,6 @@ def _register_model_function(
                 model.get_fabric(is_local),
             )
 
-        tracker.mark_model_saved(model.asset_name)
     except LayerClientServiceUnavailableException as e:
         tracker.mark_model_train_failed(model.asset_name, "")
         raise LayerServiceUnavailableExceptionDuringInitialization(str(e))

--- a/layer/tracker/asset_column.py
+++ b/layer/tracker/asset_column.py
@@ -347,6 +347,8 @@ class AssetColumn(ProgressColumn):
             text = "from cache"
         elif asset.status == AssetTrackerStatus.ASSET_LOADED:
             text = "loaded"
+        elif asset.status == AssetTrackerStatus.DONE:
+            text = "done"
         else:
             text = task.description
         if (

--- a/layer/tracker/non_ui_progress_tracker.py
+++ b/layer/tracker/non_ui_progress_tracker.py
@@ -51,7 +51,12 @@ class NonUIRunProgressTracker(RunProgressTracker):
     def mark_model_saving(self, name: str) -> None:
         pass
 
-    def mark_model_saved(self, name: str) -> None:
+    def mark_model_saved(
+        self,
+        name: str,
+        version: Optional[str] = None,
+        train_index: Optional[str] = None,
+    ) -> None:
         pass
 
     def mark_model_training(

--- a/layer/tracker/progress_tracker.py
+++ b/layer/tracker/progress_tracker.py
@@ -60,7 +60,12 @@ class RunProgressTracker(ABC):
         pass
 
     @abstractmethod
-    def mark_model_saved(self, name: str) -> None:
+    def mark_model_saved(
+        self,
+        name: str,
+        version: Optional[str] = None,
+        train_index: Optional[str] = None,
+    ) -> None:
         pass
 
     @abstractmethod

--- a/layer/tracker/ui_progress_tracker.py
+++ b/layer/tracker/ui_progress_tracker.py
@@ -1,4 +1,3 @@
-import time
 import uuid
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
@@ -62,9 +61,7 @@ class UIRunProgressTracker(RunProgressTracker):
         with self._progress:
             self._init_tasks()
             yield self
-            time.sleep(
-                0.5
-            )  # Give some time so the latest metadata gets a chance to get rendered
+            self._progress.refresh()
 
     def _get_url(self, asset_type: AssetType, name: str) -> URL:
         return AssetPath(
@@ -269,11 +266,19 @@ class UIRunProgressTracker(RunProgressTracker):
             status=AssetTrackerStatus.SAVING,
         )
 
-    def mark_model_saved(self, name: str) -> None:
+    def mark_model_saved(
+        self,
+        name: str,
+        version: Optional[str] = None,
+        train_index: Optional[str] = None,
+    ) -> None:
         self._update_asset(
             AssetType.MODEL,
             name,
             status=AssetTrackerStatus.DONE,
+            url=self._get_url(AssetType.MODEL, name),
+            version=version,
+            build_idx=train_index,
         )
 
     def mark_model_training(
@@ -304,7 +309,7 @@ class UIRunProgressTracker(RunProgressTracker):
         self._update_asset(
             AssetType.MODEL,
             name,
-            status=AssetTrackerStatus.TRAINING,
+            status=AssetTrackerStatus.DONE,
             url=self._get_url(AssetType.MODEL, name),
             version=version,
             build_idx=train_index,

--- a/layer/tracker/ui_progress_tracker.py
+++ b/layer/tracker/ui_progress_tracker.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
@@ -61,6 +62,9 @@ class UIRunProgressTracker(RunProgressTracker):
         with self._progress:
             self._init_tasks()
             yield self
+            time.sleep(
+                0.5
+            )  # Give some time so the latest metadata gets a chance to get rendered
 
     def _get_url(self, asset_type: AssetType, name: str) -> URL:
         return AssetPath(
@@ -82,7 +86,6 @@ class UIRunProgressTracker(RunProgressTracker):
         task_key = (asset_type, asset_name)
         if task_key not in self._tasks:
             task_id = self._progress.add_task(
-                status=AssetTrackerStatus.PENDING,
                 start=False,
                 asset=AssetTracker(
                     type=asset_type, name=asset_name, status=AssetTrackerStatus.PENDING
@@ -270,7 +273,7 @@ class UIRunProgressTracker(RunProgressTracker):
         self._update_asset(
             AssetType.MODEL,
             name,
-            status=AssetTrackerStatus.PENDING,
+            status=AssetTrackerStatus.DONE,
         )
 
     def mark_model_training(
@@ -301,7 +304,7 @@ class UIRunProgressTracker(RunProgressTracker):
         self._update_asset(
             AssetType.MODEL,
             name,
-            status=AssetTrackerStatus.DONE,
+            status=AssetTrackerStatus.TRAINING,
             url=self._get_url(AssetType.MODEL, name),
             version=version,
             build_idx=train_index,


### PR DESCRIPTION
Properly display asset statuses in the sdk's notebook UI.
<img width="990" alt="Screen Shot 2022-07-11 at 19 32 11" src="https://user-images.githubusercontent.com/1766321/178313219-4a93e143-6801-431d-a806-e19a3ede3e5d.png">
