### PR TITLE
Capture function metadata from decorators into the executable

### DIFF
--- a/layer/executables/function.py
+++ b/layer/executables/function.py
@@ -1,0 +1,107 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Union
+
+from layer.contracts.asset import AssetType
+from layer.executables.packager import package_function
+
+
+FunctionOutput = Union["DatasetOutput", "ModelOutput"]
+
+
+class Function:
+    def __init__(
+        self,
+        func: Callable[..., Any],
+        output: FunctionOutput,
+        pip_dependencies: List[str],
+        resources: List[Path],
+    ) -> None:
+        self._func = func
+        self._output = output
+        self._pip_dependencies = pip_dependencies
+        self._resources = resources
+
+    @staticmethod
+    def from_decorated(func: Callable[..., Any]) -> "Function":
+        output = _get_function_output(func)
+        pip_dependencies = _get_function_pip_dependencies(func)
+        resources = _get_function_resources(func)
+        return Function(
+            func, output=output, pip_dependencies=pip_dependencies, resources=resources
+        )
+
+    @property
+    def func(self) -> Callable[..., Any]:
+        return self._func
+
+    @property
+    def output(self) -> FunctionOutput:
+        return self._output
+
+    @property
+    def pip_dependencies(self) -> List[str]:
+        return self._pip_dependencies
+
+    @property
+    def resources(self) -> List[Path]:
+        return self._resources
+
+    def package(self, output_dir: Optional[Path] = None) -> Path:
+        return package_function(
+            self._func,
+            pip_dependencies=self._pip_dependencies,
+            resources=self._resources,
+            output_dir=output_dir,
+        )
+
+
+def _get_function_output(func: Callable[..., Any]) -> FunctionOutput:
+    asset_type = _get_decorator_attr(func, "asset_type")
+    asset_name = _get_decorator_attr(func, "asset_name")
+    if asset_type is None or asset_name is None:
+        raise FunctionError(
+            'either @dataset(name="...") or @model(name="...") top level decorator '
+            "is required for each function. Add @dataset or @model decorator on top of existing "
+            "decorators to run functions in Layer"
+        )
+    if asset_type == AssetType.DATASET:
+        return DatasetOutput(asset_name)
+    if asset_type == AssetType.MODEL:
+        return ModelOutput(asset_name)
+
+    raise FunctionError(f"unsupported asset type: '{asset_type}'")
+
+
+def _get_function_pip_dependencies(func: Callable[..., Any]) -> List[str]:
+    pip_packages = _get_decorator_attr(func, "pip_packages") or []
+    requirements = _get_decorator_attr(func, "pip_requirements_file")
+    if requirements is not None and len(requirements) > 0:
+        with open(requirements, "r") as f:
+            pip_packages += f.read().splitlines()
+    return pip_packages
+
+
+def _get_function_resources(func: Callable[..., Any]) -> List[Path]:
+    resource_paths = _get_decorator_attr(func, "resource_paths") or []
+    return [Path(resource_path.path) for resource_path in resource_paths]
+
+
+def _get_decorator_attr(func: Callable[..., Any], attr: str) -> Optional[Any]:
+    if hasattr(func, "layer") and hasattr(func.layer, attr):  # type: ignore
+        return getattr(func.layer, attr)  # type: ignore
+    return None
+
+
+@dataclass(frozen=True)
+class DatasetOutput:
+    name: str
+
+
+@dataclass(frozen=True)
+class ModelOutput:
+    name: str
+
+
+class FunctionError(Exception):
+    pass

--- a/layer/settings.py
+++ b/layer/settings.py
@@ -34,6 +34,26 @@ class LayerSettings:
             raise LayerClientException("Asset type cannot be empty")
         return self._asset_type
 
+    @property
+    def asset_type(self) -> AssetType:
+        return self.get_asset_type()
+
+    @property
+    def asset_name(self) -> str:
+        return self.get_asset_name()
+
+    @property
+    def pip_packages(self) -> List[str]:
+        return self.get_pip_packages()
+
+    @property
+    def pip_requirements_file(self) -> str:
+        return self.get_pip_requirements_file()
+
+    @property
+    def resource_paths(self) -> List[ResourcePath]:
+        return self.get_resource_paths()
+
     def get_asset_name(self) -> str:
         if self._name is None:
             raise LayerClientException("Asset name cannot be empty")

--- a/test/unit/executables/test_function.py
+++ b/test/unit/executables/test_function.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from layer.decorators.dataset_decorator import dataset
+from layer.decorators.model_decorator import model
+from layer.decorators.pip_requirements_decorator import pip_requirements
+from layer.decorators.resources_decorator import resources
+from layer.executables.function import (
+    DatasetOutput,
+    Function,
+    FunctionError,
+    ModelOutput,
+)
+
+
+def test_from_decorated_dataset():
+    @dataset("test_dataset")
+    def dataset_function():
+        return [
+            1,
+            2,
+            3,
+        ]
+
+    function = Function.from_decorated(dataset_function)
+    assert function.func == dataset_function
+    assert function.output == DatasetOutput("test_dataset")
+
+
+def test_from_decorated_model():
+    @model("test_model")
+    def model_function():
+        return 42
+
+    function = Function.from_decorated(model_function)
+    assert function.func == model_function
+    assert function.output == ModelOutput("test_model")
+
+
+def test_from_decorated_raises_when_required_decorators_missing():
+    def function():
+        return 42
+
+    with pytest.raises(
+        FunctionError,
+        match=r"either @dataset\(name=\"\.\.\.\"\) or @model\(name=\"\.\.\.\"\) top level decorator is required for each function\. Add @dataset or @model decorator on top of existing decorators to run functions in Layer",
+    ):
+        Function.from_decorated(function)
+
+
+def test_from_decorated_resources():
+    @dataset("test_dataset")
+    @resources("path/to/resource", "path/to/other/resource")
+    def dataset_function():
+        return [42]
+
+    function = Function.from_decorated(dataset_function)
+    assert function.resources == [
+        Path("path/to/resource"),
+        Path("path/to/other/resource"),
+    ]
+
+
+def test_from_decorated_pip_dependencies_packages():
+    @dataset("test_dataset")
+    @pip_requirements(packages=["package1", "package2==0.0.42"])
+    def dataset_function():
+        return [42]
+
+    function = Function.from_decorated(dataset_function)
+    assert function.pip_dependencies == [
+        "package1",
+        "package2==0.0.42",
+    ]
+
+
+def test_from_decorated_pip_dependencies_requirements(tmp_path):
+    pip_packages = ["package1", "package2==0.0.42"]
+    requirements_path = tmp_path / "requirements.txt"
+
+    with open(requirements_path, "w") as f:
+        f.write("\n".join(pip_packages))
+
+    @dataset("test_dataset")
+    @pip_requirements(file=str(requirements_path))
+    def dataset_function():
+        return [42]
+
+    function = Function.from_decorated(dataset_function)
+    assert function.pip_dependencies == [
+        "package1",
+        "package2==0.0.42",
+    ]
+
+
+def test_package_function():
+    package_dir = Path("package/dir")
+    package_path = Path("path/to/package")
+
+    with patch("layer.executables.function.package_function") as package_function:
+        package_function.return_value = package_path
+
+        @dataset("test_dataset")
+        @resources("path/to/resource", "path/to/other/resource")
+        @pip_requirements(packages=["package1", "package2==0.0.42"])
+        def dataset_function():
+            return [42]
+
+        function = Function.from_decorated(dataset_function)
+
+        assert function.package(output_dir=package_dir) == package_path
+        package_function.assert_called_once_with(
+            dataset_function,
+            output_dir=package_dir,
+            resources=[Path("path/to/resource"), Path("path/to/other/resource")],
+            pip_dependencies=["package1", "package2==0.0.42"],
+        )


### PR DESCRIPTION
Capture function metadata from the decorators and package them into the executable. Usage:

```python
  @dataset("test_dataset")
  @resources("path/to/resource", "path/to/other/resource")
  @pip_requirements(packages=["package1", "package2==0.0.42"])
  def dataset_function():
      return [42]

function = Function.from_decorated(dataset_function)

function.package()  # returns the path to the executable
```

Only `dataset`, `model`, `resources` and `pip_requirements` are relevant to the execution (assertions are relevant too, but will be implemented later). `fabric` decorator is the property of a runtime, hence it is not packaged.