### PR TITLE
Add group uuid to logged metrics

### DIFF
--- a/layer/clients/logged_data_service.py
+++ b/layer/clients/logged_data_service.py
@@ -62,7 +62,7 @@ class LoggedDataClient:
         train_id: UUID,
         tag: str,
         points: List[ModelMetricPoint],
-        metric_group_uuid: UUID,
+        metric_group_id: UUID,
     ) -> ModelMetricId:
         metric = LoggedModelMetric(
             unique_tag=tag,
@@ -70,7 +70,7 @@ class LoggedDataClient:
                 LoggedModelMetric.ModelMetricPoint(epoch=p.epoch, value=p.value)
                 for p in points
             ],
-            group_id=LoggedMetricGroupId(value=str(metric_group_uuid)),
+            group_id=LoggedMetricGroupId(value=str(metric_group_id)),
         )
         request = LogModelMetricRequest(
             model_train_id=ModelTrainId(value=str(train_id)), metric=metric

--- a/layer/clients/logged_data_service.py
+++ b/layer/clients/logged_data_service.py
@@ -2,7 +2,12 @@ from typing import List, Optional, cast
 from uuid import UUID
 
 from layerapi.api.entity.logged_model_metric_pb2 import LoggedModelMetric
-from layerapi.api.ids_pb2 import DatasetBuildId, ModelMetricId, ModelTrainId
+from layerapi.api.ids_pb2 import (
+    DatasetBuildId,
+    LoggedMetricGroupId,
+    ModelMetricId,
+    ModelTrainId,
+)
 from layerapi.api.service.logged_data.logged_data_api_pb2 import (
     GetLoggedDataRequest,
     LogDataRequest,
@@ -53,7 +58,11 @@ class LoggedDataClient:
         )
 
     def log_model_metric(
-        self, train_id: UUID, tag: str, points: List[ModelMetricPoint]
+        self,
+        train_id: UUID,
+        tag: str,
+        points: List[ModelMetricPoint],
+        metric_group_uuid: UUID,
     ) -> ModelMetricId:
         metric = LoggedModelMetric(
             unique_tag=tag,
@@ -61,6 +70,7 @@ class LoggedDataClient:
                 LoggedModelMetric.ModelMetricPoint(epoch=p.epoch, value=p.value)
                 for p in points
             ],
+            group_id=LoggedMetricGroupId(value=str(metric_group_uuid)),
         )
         request = LogModelMetricRequest(
             model_train_id=ModelTrainId(value=str(train_id)), metric=metric

--- a/layer/logged_data/log_data_runner.py
+++ b/layer/logged_data/log_data_runner.py
@@ -1,4 +1,5 @@
 import io
+import uuid
 from logging import Logger
 from pathlib import Path
 from types import ModuleType
@@ -57,6 +58,7 @@ class LogDataRunner:
     ) -> None:
         LogDataRunner._check_epoch(epoch)
 
+        metric_group_uuid = uuid.uuid4()
         for tag, value in data.items():
             if isinstance(value, str):
                 self._log_text(tag=tag, text=value)
@@ -65,7 +67,12 @@ class LogDataRunner:
                 self._log_boolean(tag=tag, bool_val=value)
             elif isinstance(value, (int, float)):
                 if self._train_id and epoch is not None:
-                    self._log_metric(tag=tag, numeric_value=value, epoch=epoch)
+                    self._log_metric(
+                        tag=tag,
+                        numeric_value=value,
+                        epoch=epoch,
+                        metric_group_uuid=metric_group_uuid,
+                    )
                 else:
                     self._log_number(tag=tag, number=value)
             elif isinstance(value, Markdown):
@@ -145,7 +152,11 @@ class LogDataRunner:
                 self._log_pil_image(tag=tag, image=img)
 
     def _log_metric(
-        self, tag: str, numeric_value: Union[float, int], epoch: Optional[int]
+        self,
+        tag: str,
+        numeric_value: Union[float, int],
+        epoch: Optional[int],
+        metric_group_uuid: UUID,
     ) -> None:
         assert self._train_id
         # store numeric values w/o an explicit epoch as metric with the special epoch:-1
@@ -154,6 +165,7 @@ class LogDataRunner:
             train_id=self._train_id,
             tag=tag,
             points=[ModelMetricPoint(epoch=epoch, value=float(numeric_value))],
+            metric_group_uuid=metric_group_uuid,
         )
 
     def _log_text(self, tag: str, text: str) -> None:

--- a/layer/logged_data/log_data_runner.py
+++ b/layer/logged_data/log_data_runner.py
@@ -71,7 +71,7 @@ class LogDataRunner:
                         tag=tag,
                         numeric_value=value,
                         epoch=epoch,
-                        metric_group_uuid=metric_group_uuid,
+                        metric_group_id=metric_group_uuid,
                     )
                 else:
                     self._log_number(tag=tag, number=value)
@@ -156,7 +156,7 @@ class LogDataRunner:
         tag: str,
         numeric_value: Union[float, int],
         epoch: Optional[int],
-        metric_group_uuid: UUID,
+        metric_group_id: UUID,
     ) -> None:
         assert self._train_id
         # store numeric values w/o an explicit epoch as metric with the special epoch:-1
@@ -165,7 +165,7 @@ class LogDataRunner:
             train_id=self._train_id,
             tag=tag,
             points=[ModelMetricPoint(epoch=epoch, value=float(numeric_value))],
-            metric_group_uuid=metric_group_uuid,
+            metric_group_id=metric_group_id,
         )
 
     def _log_text(self, tag: str, text: str) -> None:

--- a/layer/main.py
+++ b/layer/main.py
@@ -778,7 +778,8 @@ def log(
 
     **Charts**
 
-    You can track your metrics in detail with charts
+    You can track your metrics in detail with charts. Metrics logged with the same layer.log(...) call will be
+    grouped and visualized together in the web UI.
 
     Accepted Types:
     ``matplotlib.figure.Figure``,

--- a/test/unit/logged_data/test_log_data_runner.py
+++ b/test/unit/logged_data/test_log_data_runner.py
@@ -137,12 +137,14 @@ def test_given_runner_when_log_numeric_value_with_epoch_then_calls_log_metric() 
         train_id=train_id,
         tag=tag1,
         points=[ModelMetricPoint(epoch=epoch, value=numeric_value1)],
+        metric_group_uuid=ANY,
     )
 
     logged_data_client.log_model_metric.assert_any_call(
         train_id=train_id,
         tag=tag2,
         points=[ModelMetricPoint(epoch=epoch, value=numeric_value2)],
+        metric_group_uuid=ANY,
     )
 
 

--- a/test/unit/logged_data/test_log_data_runner.py
+++ b/test/unit/logged_data/test_log_data_runner.py
@@ -137,14 +137,14 @@ def test_given_runner_when_log_numeric_value_with_epoch_then_calls_log_metric() 
         train_id=train_id,
         tag=tag1,
         points=[ModelMetricPoint(epoch=epoch, value=numeric_value1)],
-        metric_group_uuid=ANY,
+        metric_group_id=ANY,
     )
 
     logged_data_client.log_model_metric.assert_any_call(
         train_id=train_id,
         tag=tag2,
         points=[ModelMetricPoint(epoch=epoch, value=numeric_value2)],
-        metric_group_uuid=ANY,
+        metric_group_id=ANY,
     )
 
 

--- a/test/unit/logged_data/test_logged_data_service_client.py
+++ b/test/unit/logged_data/test_logged_data_service_client.py
@@ -3,7 +3,12 @@ from unittest.mock import MagicMock
 
 import pytest
 from layerapi.api.entity.logged_model_metric_pb2 import LoggedModelMetric
-from layerapi.api.ids_pb2 import LoggedDataId, ModelMetricId, ModelTrainId
+from layerapi.api.ids_pb2 import (
+    LoggedDataId,
+    LoggedMetricGroupId,
+    ModelMetricId,
+    ModelTrainId,
+)
 from layerapi.api.service.logged_data.logged_data_api_pb2 import (
     LogDataRequest,
     LogDataResponse,
@@ -119,9 +124,12 @@ def test_given_tag_not_exists_when_log_model_metric_then_calls_log_metric():  # 
     train_id = uuid.uuid4()
     tag = "foo-test-tag"
     points = [ModelMetricPoint(epoch=1, value=1), ModelMetricPoint(epoch=2, value=2)]
+    metric_group_uuid = uuid.uuid4()
 
     # when
-    logged_data_client.log_model_metric(train_id=train_id, tag=tag, points=points)
+    logged_data_client.log_model_metric(
+        train_id=train_id, tag=tag, points=points, metric_group_uuid=metric_group_uuid
+    )
 
     # then
     mock_logged_data_api.LogModelMetric.assert_called_with(
@@ -133,6 +141,7 @@ def test_given_tag_not_exists_when_log_model_metric_then_calls_log_metric():  # 
                     LoggedModelMetric.ModelMetricPoint(epoch=1, value=1),
                     LoggedModelMetric.ModelMetricPoint(epoch=2, value=2),
                 ],
+                group_id=LoggedMetricGroupId(value=str(metric_group_uuid)),
             ),
         )
     )

--- a/test/unit/logged_data/test_logged_data_service_client.py
+++ b/test/unit/logged_data/test_logged_data_service_client.py
@@ -128,7 +128,7 @@ def test_given_tag_not_exists_when_log_model_metric_then_calls_log_metric():  # 
 
     # when
     logged_data_client.log_model_metric(
-        train_id=train_id, tag=tag, points=points, metric_group_uuid=metric_group_uuid
+        train_id=train_id, tag=tag, points=points, metric_group_id=metric_group_uuid
     )
 
     # then


### PR DESCRIPTION
Adds the `LoggedMetricGroupId` to the logged metrics request. Including this id will allow to group metrics together, so that later the UI can visualize multiple metrics in the same chart.