### PR TITLE
Implement base function runtime

### DIFF
--- a/layer/executables/runtime.py
+++ b/layer/executables/runtime.py
@@ -1,0 +1,103 @@
+import os
+import runpy
+import sys
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from layer.executables.packager import get_function_package_info
+
+
+class BaseFunctionRuntime:
+    """Base skeleton of a function runtime."""
+
+    def __init__(self, executable_path: Path) -> None:
+        self._executable_path = executable_path
+
+    def initialise(self) -> None:
+        """Any initialisation required to run the function."""
+
+    def process_function_output(self, output: Any, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    @property
+    def executable_path(self) -> Path:
+        return self._executable_path
+
+    def install_packages(self, packages: Sequence[str]) -> None:
+        """Installs packages required to run the function."""
+        _run_pip_install(packages)
+
+    def __call__(self, func: Callable[..., Any]) -> Any:
+        """Called from the executable to run the function."""
+        output = func()
+        self.process_function_output(output)
+        return output
+
+    def run_executable(self, executable_path: Path) -> Any:
+        """Runs the packaged function."""
+        runpy.run_path(
+            str(executable_path),
+            run_name="__main__",
+            init_globals={"__function_runtime": self},
+        )
+
+    @classmethod
+    def execute(cls, executable_path: Path, *args: Any, **kwargs: Any) -> None:
+        """Initialises the environment, installs packages and runs the executable."""
+        _validate_executable_path(executable_path)
+        package_info = get_function_package_info(executable_path)
+        runtime = cls(executable_path, *args, **kwargs)
+        runtime.initialise()
+        runtime.install_packages(packages=package_info.pip_dependencies)
+        runtime.run_executable(executable_path)
+
+
+def _validate_executable_path(executable_path: Path) -> None:
+    if not executable_path:
+        raise FunctionRuntimeError("executable path is required")
+    if not executable_path.exists():
+        raise FunctionRuntimeError(f"executable path does not exist: {executable_path}")
+    if not os.path.isfile(str(executable_path)):
+        raise FunctionRuntimeError(f"executable path is not a file: {executable_path}")
+
+
+class FunctionRuntimeError(Exception):
+    pass
+
+
+def _run_pip_install(packages: Sequence[str]) -> None:
+    if len(packages) == 0:
+        return
+
+    pip_install = [
+        sys.executable,
+        "-m",
+        "pip",
+        "--quiet",
+        "--disable-pip-version-check",
+        "install",
+    ] + list(packages)
+
+    import subprocess  # nosec
+
+    subprocess.check_call(pip_install)  # nosec
+
+
+def main() -> None:
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser(description="Function runtime")
+
+    parser.add_argument(
+        "executable_path",
+        type=Path,
+        help="the local file path of the executable",
+    )
+
+    args = parser.parse_args()
+
+    BaseFunctionRuntime.execute(args.executable_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/unit/executables/test_runtime.py
+++ b/test/unit/executables/test_runtime.py
@@ -1,0 +1,101 @@
+import contextlib
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from layer.executables.packager import package_function
+from layer.executables.runtime import BaseFunctionRuntime, FunctionRuntimeError
+
+
+def test_executable_path_does_not_exist():
+    executable_path = Path("does_not_exist")
+    with pytest.raises(
+        FunctionRuntimeError, match="executable path does not exist: does_not_exist"
+    ):
+        BaseFunctionRuntime.execute(executable_path)
+
+
+def test_executable_path_is_not_a_file(tmpdir: Path):
+    with pytest.raises(FunctionRuntimeError, match="executable path is not a file: "):
+        BaseFunctionRuntime.execute(tmpdir)
+
+
+def test_execute_func_simple(tmpdir: Path, capsys: Any):
+    executable = package_function(func_simple, output_dir=tmpdir)
+    BaseFunctionRuntime.execute(executable)
+
+    assert "running simple function" in capsys.readouterr().out
+
+
+def test_execute_func_with_resources(tmpdir: Path, capsys: Any):
+    resources_parent = Path("test") / "unit" / "executables" / "data"
+    resource_paths = [
+        resources_parent / "1",
+        resources_parent / "dir" / "a",
+        resources_parent / "dir" / "2",
+    ]
+
+    def func_with_resources():
+        content = ""
+        for resource_path in resource_paths:
+            resource = Path(resource_path)
+            if resource.is_file():
+                with open(resource_path, "r") as f:
+                    content += f"file:{resource}={f.read()},"
+            elif resource.is_dir():
+                content += f"dir:{resource},"
+        print(f"content is '{content}'")
+
+    executable = package_function(
+        func_with_resources, resources=resource_paths, output_dir=tmpdir
+    )
+    BaseFunctionRuntime.execute(executable)
+
+    assert (
+        "content is 'file:test/unit/executables/data/1=1,dir:test/unit/executables/data/dir/a,file:test/unit/executables/data/dir/2=2,'"
+        in capsys.readouterr().out
+    )
+
+
+def test_execute_func_with_packages(tmpdir: Path):
+    def function_with_packages():
+        import marshmallow  # type: ignore
+
+        print(f"running marshmallow version {marshmallow.__version__}")
+
+    executable = package_function(
+        function_with_packages,
+        pip_dependencies=["marshmallow==3.17.0"],
+        output_dir=tmpdir,
+    )
+    result = _execute_runtime_module(executable)
+
+    assert "running marshmallow version 3.17.0" in result.stdout
+
+
+def func_simple() -> None:
+    print("running simple function")
+
+
+@contextlib.contextmanager
+def _virtual_env_python() -> Path:
+    import venv
+
+    with tempfile.TemporaryDirectory() as venv_dir:
+        python_bin = Path(venv_dir) / "bin" / "python"
+        venv.create(venv_dir, with_pip=True, system_site_packages=True)
+        yield python_bin
+
+
+def _execute_runtime_module(executable: Path) -> subprocess.CompletedProcess:
+    with _virtual_env_python() as python_bin:
+        # run in a virtual environment, not to mess the current one
+        return subprocess.run(
+            [python_bin, "-m", "layer.executables.runtime", str(executable)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )


### PR DESCRIPTION
Skeleton contract between the function executable package and the runtime.

Basically, when started, the executable package asks for the runtime available by trying to call a global `__function_runtime` attribute. If one is provided, the executable will pass the loaded function to the runtime for execution.

All runtime implementations will extend the `BaseFunctionRuntime` class, which is a skeleton of a function execution workflow.

More concrete implementations will follow.