### PR TITLE
Do not package layer decorators into the executable

### DIFF
--- a/test/unit/executables/test_function.py
+++ b/test/unit/executables/test_function.py
@@ -1,9 +1,13 @@
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from layer.decorators.assertions import assert_unique
 from layer.decorators.dataset_decorator import dataset
+from layer.decorators.fabric_decorator import fabric
 from layer.decorators.model_decorator import model
 from layer.decorators.pip_requirements_decorator import pip_requirements
 from layer.decorators.resources_decorator import resources
@@ -12,6 +16,7 @@ from layer.executables.function import (
     Function,
     FunctionError,
     ModelOutput,
+    _undecorate_function,
 )
 
 
@@ -117,3 +122,103 @@ def test_package_function():
             resources=(Path("path/to/resource"), Path("path/to/other/resource")),
             pip_dependencies=("package1", "package2==0.0.42"),
         )
+
+
+def test_undecorate_function_dataset_decorator():
+    @dataset("x")
+    def f1():
+        return [42]
+
+    assert type(_undecorate_function(f1)).__name__ == "function"
+
+
+def test_undecorate_function_model_decorator():
+    @model("x")
+    def f1():
+        return [42]
+
+    assert type(_undecorate_function(f1)).__name__ == "function"
+
+
+def test_undecorate_function_pip_requirements_decorator():
+    @pip_requirements(packages=["package1", "package2==0.0.42"])
+    def f1():
+        return [42]
+
+    assert type(_undecorate_function(f1)).__name__ == "function"
+
+
+def test_undecorate_function_assert_unique_decorator():
+    @assert_unique(["x"])
+    def f1():
+        return [42]
+
+    assert type(_undecorate_function(f1)).__name__ == "function"
+
+
+def test_undecorate_function_fabric_decorator():
+    @fabric("f-medium")
+    def f1():
+        return [42]
+
+    assert type(_undecorate_function(f1)).__name__ == "function"
+
+
+def test_undecorate_function_resources_decorator():
+    @resources("path/to/resource", "path/to/other/resource")
+    def f1():
+        return [42]
+
+    assert type(_undecorate_function(f1)).__name__ == "function"
+
+
+def test_undecorate_function_from_multiple_decorators():
+    @dataset("x")
+    @pip_requirements(packages=["package1", "package2==0.0.42"])
+    def f1():
+        return [42]
+
+    assert type(_undecorate_function(f1)).__name__ == "function"
+
+
+def test_undecorate_function_custom_decorator():
+    def custom_decorator(func):
+        def wrapper():
+            return func() + 1
+
+        return wrapper
+
+    @custom_decorator
+    def f1():
+        return 42
+
+    undecorated = _undecorate_function(f1)
+
+    assert type(undecorated).__name__ == "function"
+    assert undecorated() == 43
+
+
+def test_undecorate_function_no_decorator():
+    def f1():
+        return 42
+
+    undecorated = _undecorate_function(f1)
+
+    assert type(undecorated).__name__ == "function"
+    assert undecorated() == 42
+
+
+def test_packaged_function_is_unwrapped_from_all_the_decorators(tmpdir: Path):
+    @dataset("test_dataset")
+    @resources("path/to/resource", "path/to/other/resource")
+    @pip_requirements(packages=["package1", "package2==0.0.42"])
+    def dataset_function():
+        return [42]
+
+    function = Function.from_decorated(dataset_function)
+    executable = function.package(output_dir=tmpdir)
+
+    # the packaged function should be an instance of a built-in function class
+    assert type(function.func).__name__ == "function"
+    # the decorators should have no effect on the function execution (fails otherwise)
+    assert subprocess.check_call([sys.executable, str(executable)]) == 0


### PR DESCRIPTION
Do not package layer decorators into the executable to avoid side effects when executable is run (requiring a project to be created in the `dataset` decorator, for example).