### PR TITLE
Reuse grpc channel in layer client

### DIFF
--- a/layer/clients/account_service.py
+++ b/layer/clients/account_service.py
@@ -1,7 +1,5 @@
 import uuid
-from contextlib import contextmanager
 from logging import Logger
-from typing import Iterator
 
 from layerapi.api.ids_pb2 import AccountId
 from layerapi.api.service.account.account_api_pb2 import (
@@ -13,7 +11,7 @@ from layerapi.api.service.account.account_api_pb2_grpc import AccountAPIStub
 
 from layer.config import ClientConfig
 from layer.contracts.accounts import Account
-from layer.utils.grpc import create_grpc_channel
+from layer.utils.grpc.channel import get_grpc_channel
 
 
 class AccountServiceClient:
@@ -30,16 +28,14 @@ class AccountServiceClient:
         self._do_verify_ssl = config.grpc_do_verify_ssl
         self._logs_file_path = config.logs_file_path
 
-    @contextmanager
-    def init(self) -> Iterator["AccountServiceClient"]:
-        with create_grpc_channel(
-            self._grpc_gateway_address,
-            self._access_token,
-            do_verify_ssl=self._do_verify_ssl,
-            logs_file_path=self._logs_file_path,
-        ) as channel:
-            self._account_api = AccountAPIStub(channel=channel)
-            yield self
+    @staticmethod
+    def create(config: ClientConfig, logger: Logger) -> "AccountServiceClient":
+        client = AccountServiceClient(config=config, logger=logger)
+        channel = get_grpc_channel(config)
+        client._account_api = AccountAPIStub(  # pylint: disable=protected-access
+            channel
+        )
+        return client
 
     def get_account_name_by_id(self, account_id: uuid.UUID) -> str:
         get_my_org_resp: GetAccountViewByIdResponse = (

--- a/layer/clients/account_service.py
+++ b/layer/clients/account_service.py
@@ -1,5 +1,4 @@
 import uuid
-from logging import Logger
 
 from layerapi.api.ids_pb2 import AccountId
 from layerapi.api.service.account.account_api_pb2 import (
@@ -17,20 +16,9 @@ from layer.utils.grpc.channel import get_grpc_channel
 class AccountServiceClient:
     _account_api: AccountAPIStub
 
-    def __init__(
-        self,
-        config: ClientConfig,
-        logger: Logger,
-    ):
-        self._grpc_gateway_address = config.grpc_gateway_address
-        self._logger = logger
-        self._access_token = config.access_token
-        self._do_verify_ssl = config.grpc_do_verify_ssl
-        self._logs_file_path = config.logs_file_path
-
     @staticmethod
-    def create(config: ClientConfig, logger: Logger) -> "AccountServiceClient":
-        client = AccountServiceClient(config=config, logger=logger)
+    def create(config: ClientConfig) -> "AccountServiceClient":
+        client = AccountServiceClient()
         channel = get_grpc_channel(config)
         client._account_api = AccountAPIStub(  # pylint: disable=protected-access
             channel

--- a/layer/clients/data_catalog.py
+++ b/layer/clients/data_catalog.py
@@ -40,7 +40,6 @@ from layerapi.api.value.python_source_pb2 import PythonSource
 from layerapi.api.value.s3_path_pb2 import S3Path
 from layerapi.api.value.storage_location_pb2 import StorageLocation
 from layerapi.api.value.ticket_pb2 import DatasetPathTicket, DataTicket
-from pyarrow import flight
 
 from layer.config import ClientConfig
 from layer.contracts.assets import AssetPath, AssetType
@@ -63,19 +62,10 @@ class DataCatalogClient:
         self,
         config: ClientConfig,
         logger: Logger,
-        *,
-        service_factory: Callable[..., DataCatalogAPIStub] = DataCatalogAPIStub,
-        flight_client: flight.FlightClient = None,
         dataset_client: Optional["DatasetClient"] = None,
     ):
-        self._grpc_gateway_address = config.grpc_gateway_address
         self._logger = logger
-        self._service_factory = service_factory
-        self._access_token = config.access_token
         self._call_metadata = [("authorization", f"Bearer {config.access_token}")]
-        self._flight_client = flight_client
-        self._do_verify_ssl = config.grpc_do_verify_ssl
-        self._logs_file_path = config.logs_file_path
         self._s3_endpoint_url = config.s3.endpoint_url
         self._dataset_client = (
             DatasetClient(

--- a/layer/clients/executor_service.py
+++ b/layer/clients/executor_service.py
@@ -1,5 +1,3 @@
-from logging import Logger
-
 from layerapi.api.service.executor.executor_api_pb2 import GetFunctionUploadPathRequest
 from layerapi.api.service.executor.executor_api_pb2_grpc import ExecutorAPIStub
 
@@ -11,20 +9,9 @@ from layer.utils.grpc.channel import get_grpc_channel
 class ExecutorClient:
     _service: ExecutorAPIStub
 
-    def __init__(
-        self,
-        config: ClientConfig,
-        logger: Logger,
-    ):
-        self._grpc_gateway_address = config.grpc_gateway_address
-        self._logger = logger
-        self._access_token = config.access_token
-        self._do_verify_ssl = config.grpc_do_verify_ssl
-        self._logs_file_path = config.logs_file_path
-
     @staticmethod
-    def create(config: ClientConfig, logger: Logger) -> "ExecutorClient":
-        client = ExecutorClient(config=config, logger=logger)
+    def create(config: ClientConfig) -> "ExecutorClient":
+        client = ExecutorClient()
         channel = get_grpc_channel(config)
         client._service = ExecutorAPIStub(channel)  # pylint: disable=protected-access
         return client

--- a/layer/clients/flow_manager.py
+++ b/layer/clients/flow_manager.py
@@ -1,4 +1,3 @@
-from logging import Logger
 from typing import List, Tuple
 
 from layerapi.api.entity.history_event_pb2 import HistoryEvent
@@ -24,20 +23,9 @@ from layer.utils.grpc.channel import get_grpc_channel
 class FlowManagerClient:
     _service: FlowManagerAPIStub
 
-    def __init__(
-        self,
-        config: ClientConfig,
-        logger: Logger,
-    ):
-        self._grpc_gateway_address = config.grpc_gateway_address
-        self._logger = logger
-        self._access_token = config.access_token
-        self._do_verify_ssl = config.grpc_do_verify_ssl
-        self._logs_file_path = config.logs_file_path
-
     @staticmethod
-    def create(config: ClientConfig, logger: Logger) -> "FlowManagerClient":
-        client = FlowManagerClient(config=config, logger=logger)
+    def create(config: ClientConfig) -> "FlowManagerClient":
+        client = FlowManagerClient()
         channel = get_grpc_channel(config)
         client._service = FlowManagerAPIStub(  # pylint: disable=protected-access
             channel

--- a/layer/clients/layer.py
+++ b/layer/clients/layer.py
@@ -24,7 +24,7 @@ class LayerClient:
         self._model_catalog: Optional[ModelCatalogClient] = None
         self._model_training: Optional[ModelTrainingClient] = None
         self._account: Optional[AccountServiceClient] = None
-        self._flow_manager = FlowManagerClient(config, logger)
+        self._flow_manager: Optional[FlowManagerClient] = None
         self._user_logs = UserLogsClient(config, logger)
         self._project_service_client: Optional[ProjectServiceClient] = None
         self._logged_data_client = LoggedDataClient(config, logger)
@@ -33,7 +33,6 @@ class LayerClient:
     @contextmanager
     def init(self) -> Iterator["LayerClient"]:
         with ExitStack() as exit_stack:
-            exit_stack.enter_context(self._flow_manager.init())
             exit_stack.enter_context(self._user_logs.init())
             exit_stack.enter_context(self._executor_client.init())
             exit_stack.enter_context(self._logged_data_client.init())
@@ -67,6 +66,8 @@ class LayerClient:
 
     @property
     def flow_manager(self) -> FlowManagerClient:
+        if self._flow_manager is None:
+            self._flow_manager = FlowManagerClient.create(self._config, self._logger)
         return self._flow_manager
 
     @property

--- a/layer/clients/layer.py
+++ b/layer/clients/layer.py
@@ -26,7 +26,7 @@ class LayerClient:
         self._account = AccountServiceClient(config, logger)
         self._flow_manager = FlowManagerClient(config, logger)
         self._user_logs = UserLogsClient(config, logger)
-        self._project_service_client = ProjectServiceClient(config, logger)
+        self._project_service_client: Optional[ProjectServiceClient] = None
         self._logged_data_client = LoggedDataClient(config, logger)
         self._executor_client = ExecutorClient(config, logger)
 
@@ -38,7 +38,6 @@ class LayerClient:
             exit_stack.enter_context(self._account.init())
             exit_stack.enter_context(self._flow_manager.init())
             exit_stack.enter_context(self._user_logs.init())
-            exit_stack.enter_context(self.project_service_client.init())
             exit_stack.enter_context(self._executor_client.init())
             exit_stack.enter_context(self._logged_data_client.init())
             yield self
@@ -71,6 +70,10 @@ class LayerClient:
 
     @property
     def project_service_client(self) -> ProjectServiceClient:
+        if self._project_service_client is None:
+            self._project_service_client = ProjectServiceClient.create(
+                self._config, self._logger
+            )
         return self._project_service_client
 
     @property

--- a/layer/clients/layer.py
+++ b/layer/clients/layer.py
@@ -28,12 +28,11 @@ class LayerClient:
         self._user_logs: Optional[UserLogsClient] = None
         self._project_service_client: Optional[ProjectServiceClient] = None
         self._logged_data_client: Optional[LoggedDataClient] = None
-        self._executor_client = ExecutorClient(config, logger)
+        self._executor_client: Optional[ExecutorClient] = None
 
     @contextmanager
     def init(self) -> Iterator["LayerClient"]:
-        with ExitStack() as exit_stack:
-            exit_stack.enter_context(self._executor_client.init())
+        with ExitStack():
             yield self
 
     @property
@@ -92,6 +91,8 @@ class LayerClient:
 
     @property
     def executor_service_client(self) -> ExecutorClient:
+        if self._executor_client is None:
+            self._executor_client = ExecutorClient.create(self._config, self._logger)
         return self._executor_client
 
     def close(self) -> None:

--- a/layer/clients/layer.py
+++ b/layer/clients/layer.py
@@ -22,7 +22,7 @@ class LayerClient:
         self._logger = logger
         self._data_catalog: Optional[DataCatalogClient] = None
         self._model_catalog: Optional[ModelCatalogClient] = None
-        self._model_training = ModelTrainingClient(config, logger)
+        self._model_training: Optional[ModelTrainingClient] = None
         self._account = AccountServiceClient(config, logger)
         self._flow_manager = FlowManagerClient(config, logger)
         self._user_logs = UserLogsClient(config, logger)
@@ -33,7 +33,6 @@ class LayerClient:
     @contextmanager
     def init(self) -> Iterator["LayerClient"]:
         with ExitStack() as exit_stack:
-            exit_stack.enter_context(self._model_training.init())
             exit_stack.enter_context(self._account.init())
             exit_stack.enter_context(self._flow_manager.init())
             exit_stack.enter_context(self._user_logs.init())
@@ -55,6 +54,10 @@ class LayerClient:
 
     @property
     def model_training(self) -> ModelTrainingClient:
+        if self._model_training is None:
+            self._model_training = ModelTrainingClient.create(
+                self._config, self._logger
+            )
         return self._model_training
 
     @property

--- a/layer/clients/layer.py
+++ b/layer/clients/layer.py
@@ -25,7 +25,7 @@ class LayerClient:
         self._model_training: Optional[ModelTrainingClient] = None
         self._account: Optional[AccountServiceClient] = None
         self._flow_manager: Optional[FlowManagerClient] = None
-        self._user_logs = UserLogsClient(config, logger)
+        self._user_logs: Optional[UserLogsClient] = None
         self._project_service_client: Optional[ProjectServiceClient] = None
         self._logged_data_client = LoggedDataClient(config, logger)
         self._executor_client = ExecutorClient(config, logger)
@@ -33,7 +33,6 @@ class LayerClient:
     @contextmanager
     def init(self) -> Iterator["LayerClient"]:
         with ExitStack() as exit_stack:
-            exit_stack.enter_context(self._user_logs.init())
             exit_stack.enter_context(self._executor_client.init())
             exit_stack.enter_context(self._logged_data_client.init())
             yield self
@@ -72,6 +71,8 @@ class LayerClient:
 
     @property
     def user_logs(self) -> UserLogsClient:
+        if self._user_logs is None:
+            self._user_logs = UserLogsClient.create(self._config, self._logger)
         return self._user_logs
 
     @property

--- a/layer/clients/layer.py
+++ b/layer/clients/layer.py
@@ -32,7 +32,8 @@ class LayerClient:
 
     @contextmanager
     def init(self) -> Iterator["LayerClient"]:
-        # kept for backwards compatibility only
+        # kept for backwards compatibility only, remove in future version:
+        # https://linear.app/layer/issue/LAY-3547/remove-layerclientconfigclient-loggerinit-method
         yield self
 
     @property

--- a/layer/clients/layer.py
+++ b/layer/clients/layer.py
@@ -21,7 +21,7 @@ class LayerClient:
         self._config = config
         self._logger = logger
         self._data_catalog: Optional[DataCatalogClient] = None
-        self._model_catalog = ModelCatalogClient(config, logger)
+        self._model_catalog: Optional[ModelCatalogClient] = None
         self._model_training = ModelTrainingClient(config, logger)
         self._account = AccountServiceClient(config, logger)
         self._flow_manager = FlowManagerClient(config, logger)
@@ -33,7 +33,6 @@ class LayerClient:
     @contextmanager
     def init(self) -> Iterator["LayerClient"]:
         with ExitStack() as exit_stack:
-            exit_stack.enter_context(self._model_catalog.init())
             exit_stack.enter_context(self._model_training.init())
             exit_stack.enter_context(self._account.init())
             exit_stack.enter_context(self._flow_manager.init())
@@ -50,6 +49,8 @@ class LayerClient:
 
     @property
     def model_catalog(self) -> ModelCatalogClient:
+        if self._model_catalog is None:
+            self._model_catalog = ModelCatalogClient.create(self._config, self._logger)
         return self._model_catalog
 
     @property

--- a/layer/clients/layer.py
+++ b/layer/clients/layer.py
@@ -23,7 +23,7 @@ class LayerClient:
         self._data_catalog: Optional[DataCatalogClient] = None
         self._model_catalog: Optional[ModelCatalogClient] = None
         self._model_training: Optional[ModelTrainingClient] = None
-        self._account = AccountServiceClient(config, logger)
+        self._account: Optional[AccountServiceClient] = None
         self._flow_manager = FlowManagerClient(config, logger)
         self._user_logs = UserLogsClient(config, logger)
         self._project_service_client: Optional[ProjectServiceClient] = None
@@ -33,7 +33,6 @@ class LayerClient:
     @contextmanager
     def init(self) -> Iterator["LayerClient"]:
         with ExitStack() as exit_stack:
-            exit_stack.enter_context(self._account.init())
             exit_stack.enter_context(self._flow_manager.init())
             exit_stack.enter_context(self._user_logs.init())
             exit_stack.enter_context(self._executor_client.init())
@@ -62,6 +61,8 @@ class LayerClient:
 
     @property
     def account(self) -> AccountServiceClient:
+        if self._account is None:
+            self._account = AccountServiceClient.create(self._config, self._logger)
         return self._account
 
     @property

--- a/layer/clients/layer.py
+++ b/layer/clients/layer.py
@@ -60,41 +60,37 @@ class LayerClient:
     @property
     def account(self) -> AccountServiceClient:
         if self._account is None:
-            self._account = AccountServiceClient.create(self._config, self._logger)
+            self._account = AccountServiceClient.create(self._config)
         return self._account
 
     @property
     def flow_manager(self) -> FlowManagerClient:
         if self._flow_manager is None:
-            self._flow_manager = FlowManagerClient.create(self._config, self._logger)
+            self._flow_manager = FlowManagerClient.create(self._config)
         return self._flow_manager
 
     @property
     def user_logs(self) -> UserLogsClient:
         if self._user_logs is None:
-            self._user_logs = UserLogsClient.create(self._config, self._logger)
+            self._user_logs = UserLogsClient.create(self._config)
         return self._user_logs
 
     @property
     def project_service_client(self) -> ProjectServiceClient:
         if self._project_service_client is None:
-            self._project_service_client = ProjectServiceClient.create(
-                self._config, self._logger
-            )
+            self._project_service_client = ProjectServiceClient.create(self._config)
         return self._project_service_client
 
     @property
     def logged_data_service_client(self) -> LoggedDataClient:
         if self._logged_data_client is None:
-            self._logged_data_client = LoggedDataClient.create(
-                self._config, self._logger
-            )
+            self._logged_data_client = LoggedDataClient.create(self._config)
         return self._logged_data_client
 
     @property
     def executor_service_client(self) -> ExecutorClient:
         if self._executor_client is None:
-            self._executor_client = ExecutorClient.create(self._config, self._logger)
+            self._executor_client = ExecutorClient.create(self._config)
         return self._executor_client
 
     def close(self) -> None:

--- a/layer/clients/layer.py
+++ b/layer/clients/layer.py
@@ -32,10 +32,8 @@ class LayerClient:
 
     @contextmanager
     def init(self) -> Iterator["LayerClient"]:
-        try:
-            yield self
-        finally:
-            self.close()
+        # kept for backwards compatibility only
+        yield self
 
     @property
     def data_catalog(self) -> DataCatalogClient:

--- a/layer/clients/layer.py
+++ b/layer/clients/layer.py
@@ -1,4 +1,4 @@
-from contextlib import ExitStack, contextmanager
+from contextlib import contextmanager
 from logging import Logger
 from typing import Iterator, Optional
 
@@ -32,8 +32,10 @@ class LayerClient:
 
     @contextmanager
     def init(self) -> Iterator["LayerClient"]:
-        with ExitStack():
+        try:
             yield self
+        finally:
+            self.close()
 
     @property
     def data_catalog(self) -> DataCatalogClient:

--- a/layer/clients/layer.py
+++ b/layer/clients/layer.py
@@ -27,14 +27,13 @@ class LayerClient:
         self._flow_manager: Optional[FlowManagerClient] = None
         self._user_logs: Optional[UserLogsClient] = None
         self._project_service_client: Optional[ProjectServiceClient] = None
-        self._logged_data_client = LoggedDataClient(config, logger)
+        self._logged_data_client: Optional[LoggedDataClient] = None
         self._executor_client = ExecutorClient(config, logger)
 
     @contextmanager
     def init(self) -> Iterator["LayerClient"]:
         with ExitStack() as exit_stack:
             exit_stack.enter_context(self._executor_client.init())
-            exit_stack.enter_context(self._logged_data_client.init())
             yield self
 
     @property
@@ -85,6 +84,10 @@ class LayerClient:
 
     @property
     def logged_data_service_client(self) -> LoggedDataClient:
+        if self._logged_data_client is None:
+            self._logged_data_client = LoggedDataClient.create(
+                self._config, self._logger
+            )
         return self._logged_data_client
 
     @property

--- a/layer/clients/logged_data_service.py
+++ b/layer/clients/logged_data_service.py
@@ -1,6 +1,5 @@
-from contextlib import contextmanager
 from logging import Logger
-from typing import Iterator, List, Optional, cast
+from typing import List, Optional, cast
 from uuid import UUID
 
 from layerapi.api.entity.logged_model_metric_pb2 import LoggedModelMetric
@@ -18,7 +17,7 @@ from layer.config import ClientConfig
 from layer.contracts.logged_data import LoggedData
 from layer.contracts.logged_data import LoggedDataType as LDType
 from layer.contracts.logged_data import ModelMetricPoint
-from layer.utils.grpc import create_grpc_channel
+from layer.utils.grpc.channel import get_grpc_channel
 
 
 class LoggedDataClient:
@@ -35,16 +34,12 @@ class LoggedDataClient:
         self._do_verify_ssl = config.grpc_do_verify_ssl
         self._logs_file_path = config.logs_file_path
 
-    @contextmanager
-    def init(self) -> Iterator["LoggedDataClient"]:
-        with create_grpc_channel(
-            self._config.grpc_gateway_address,
-            self._access_token,
-            do_verify_ssl=self._do_verify_ssl,
-            logs_file_path=self._logs_file_path,
-        ) as channel:
-            self._service = LoggedDataAPIStub(channel=channel)
-            yield self
+    @staticmethod
+    def create(config: ClientConfig, logger: Logger) -> "LoggedDataClient":
+        client = LoggedDataClient(config=config, logger=logger)
+        channel = get_grpc_channel(config)
+        client._service = LoggedDataAPIStub(channel)  # pylint: disable=protected-access
+        return client
 
     def get_logged_data(
         self,

--- a/layer/clients/logged_data_service.py
+++ b/layer/clients/logged_data_service.py
@@ -1,4 +1,3 @@
-from logging import Logger
 from typing import List, Optional, cast
 from uuid import UUID
 
@@ -23,20 +22,9 @@ from layer.utils.grpc.channel import get_grpc_channel
 class LoggedDataClient:
     _service: LoggedDataAPIStub
 
-    def __init__(
-        self,
-        config: ClientConfig,
-        logger: Logger,
-    ):
-        self._config = config
-        self._logger = logger
-        self._access_token = config.access_token
-        self._do_verify_ssl = config.grpc_do_verify_ssl
-        self._logs_file_path = config.logs_file_path
-
     @staticmethod
-    def create(config: ClientConfig, logger: Logger) -> "LoggedDataClient":
-        client = LoggedDataClient(config=config, logger=logger)
+    def create(config: ClientConfig) -> "LoggedDataClient":
+        client = LoggedDataClient()
         channel = get_grpc_channel(config)
         client._service = LoggedDataAPIStub(channel)  # pylint: disable=protected-access
         return client

--- a/layer/clients/model_catalog.py
+++ b/layer/clients/model_catalog.py
@@ -60,13 +60,8 @@ class ModelCatalogClient:
     def __init__(
         self, config: ClientConfig, logger: Logger, cache_dir: Optional[Path] = None
     ):
-        self._grpc_gateway_address = config.grpc_gateway_address
         self._s3_endpoint_url = config.s3.endpoint_url
         self._logger = logger
-        self._access_token = config.access_token
-        self._do_verify_ssl = config.grpc_do_verify_ssl
-        self._logs_file_path = config.logs_file_path
-
         self._cache = Cache(cache_dir).initialise()
 
     @staticmethod

--- a/layer/clients/model_training_service.py
+++ b/layer/clients/model_training_service.py
@@ -35,12 +35,8 @@ class ModelTrainingClient:
         config: ClientConfig,
         logger: Logger,
     ):
-        self._grpc_gateway_address = config.grpc_gateway_address
         self._logger = logger
-        self._access_token = config.access_token
         self._s3_endpoint_url = config.s3.endpoint_url
-        self._do_verify_ssl = config.grpc_do_verify_ssl
-        self._logs_file_path = config.logs_file_path
 
     @staticmethod
     def create(config: ClientConfig, logger: Logger) -> "ModelTrainingClient":

--- a/layer/clients/project_service.py
+++ b/layer/clients/project_service.py
@@ -1,5 +1,4 @@
 import uuid
-from logging import Logger
 from typing import Optional
 from uuid import UUID
 
@@ -32,20 +31,9 @@ from layer.utils.grpc.channel import get_grpc_channel
 class ProjectServiceClient:
     _service: ProjectAPIStub
 
-    def __init__(
-        self,
-        config: ClientConfig,
-        logger: Logger,
-    ):
-        self._grpc_gateway_address = config.grpc_gateway_address
-        self._logger = logger
-        self._access_token = config.access_token
-        self._do_verify_ssl = config.grpc_do_verify_ssl
-        self._logs_file_path = config.logs_file_path
-
     @staticmethod
-    def create(config: ClientConfig, logger: Logger) -> "ProjectServiceClient":
-        client = ProjectServiceClient(config=config, logger=logger)
+    def create(config: ClientConfig) -> "ProjectServiceClient":
+        client = ProjectServiceClient()
         channel = get_grpc_channel(config)
         client._service = ProjectAPIStub(channel)  # pylint: disable=protected-access
         return client

--- a/layer/clients/user_logs_service.py
+++ b/layer/clients/user_logs_service.py
@@ -1,5 +1,4 @@
 import uuid
-from logging import Logger
 from typing import TYPE_CHECKING, List, Tuple
 
 from layerapi.api.entity.user_log_line_pb2 import UserLogLine
@@ -21,20 +20,9 @@ if TYPE_CHECKING:
 class UserLogsClient:
     _service: UserLogsAPIStub
 
-    def __init__(
-        self,
-        config: ClientConfig,
-        logger: Logger,
-    ):
-        self._grpc_gateway_address = config.grpc_gateway_address
-        self._logger = logger
-        self._access_token = config.access_token
-        self._do_verify_ssl = config.grpc_do_verify_ssl
-        self._logs_file_path = config.logs_file_path
-
     @staticmethod
-    def create(config: ClientConfig, logger: Logger) -> "UserLogsClient":
-        client = UserLogsClient(config=config, logger=logger)
+    def create(config: ClientConfig) -> "UserLogsClient":
+        client = UserLogsClient()
         channel = get_grpc_channel(config)
         client._service = UserLogsAPIStub(channel)  # pylint: disable=protected-access
         return client

--- a/layer/clients/user_logs_service.py
+++ b/layer/clients/user_logs_service.py
@@ -1,7 +1,6 @@
 import uuid
-from contextlib import contextmanager
 from logging import Logger
-from typing import TYPE_CHECKING, Iterator, List, Tuple
+from typing import TYPE_CHECKING, List, Tuple
 
 from layerapi.api.entity.user_log_line_pb2 import UserLogLine
 from layerapi.api.ids_pb2 import RunId
@@ -12,7 +11,7 @@ from layerapi.api.service.user_logs.user_logs_api_pb2 import (
 from layerapi.api.service.user_logs.user_logs_api_pb2_grpc import UserLogsAPIStub
 
 from layer.config import ClientConfig
-from layer.utils.grpc import create_grpc_channel
+from layer.utils.grpc.channel import get_grpc_channel
 
 
 if TYPE_CHECKING:
@@ -33,16 +32,12 @@ class UserLogsClient:
         self._do_verify_ssl = config.grpc_do_verify_ssl
         self._logs_file_path = config.logs_file_path
 
-    @contextmanager
-    def init(self) -> Iterator["UserLogsClient"]:
-        with create_grpc_channel(
-            self._grpc_gateway_address,
-            self._access_token,
-            do_verify_ssl=self._do_verify_ssl,
-            logs_file_path=self._logs_file_path,
-        ) as channel:
-            self._service = UserLogsAPIStub(channel=channel)
-            yield self
+    @staticmethod
+    def create(config: ClientConfig, logger: Logger) -> "UserLogsClient":
+        client = UserLogsClient(config=config, logger=logger)
+        channel = get_grpc_channel(config)
+        client._service = UserLogsAPIStub(channel)  # pylint: disable=protected-access
+        return client
 
     def get_pipeline_run_logs(
         self, run_id: uuid.UUID, continuation_token: str

--- a/layer/config/guest_login_client.py
+++ b/layer/config/guest_login_client.py
@@ -1,14 +1,28 @@
+from collections import namedtuple
+
 from layerapi.api.service.account.user_api_pb2 import GetGuestAuthTokenRequest
 from layerapi.api.service.account.user_api_pb2_grpc import UserAPIStub
 
 from layer.config import LogsConfig
-from layer.utils.grpc import create_grpc_channel
+from layer.utils.grpc.channel import get_grpc_channel
+
+
+_ChannelConfig = namedtuple(
+    "_ChannelConfig", ("grpc_gateway_address", "access_token", "logs_file_path")
+)
+
+
+def _get_channel_config(url: str) -> _ChannelConfig:
+    return _ChannelConfig(
+        grpc_gateway_address=url,
+        access_token="",
+        logs_file_path=LogsConfig().logs_file_path,
+    )
 
 
 def get_guest_auth_token(url: str) -> str:
-    with create_grpc_channel(
-        url, "", logs_file_path=LogsConfig().logs_file_path
-    ) as channel:
-        svc = UserAPIStub(channel=channel)
-        auth_token = svc.GetGuestAuthToken(GetGuestAuthTokenRequest())
-        return auth_token.token
+    config = _get_channel_config(url)
+    channel = get_grpc_channel(config)
+    user_service = UserAPIStub(channel)
+    auth_token = user_service.GetGuestAuthToken(GetGuestAuthTokenRequest())
+    return auth_token.token

--- a/layer/config/guest_login_client.py
+++ b/layer/config/guest_login_client.py
@@ -8,7 +8,8 @@ from layer.utils.grpc.channel import get_grpc_channel
 
 
 _ChannelConfig = namedtuple(
-    "_ChannelConfig", ("grpc_gateway_address", "access_token", "logs_file_path")
+    "_ChannelConfig",
+    ("grpc_gateway_address", "access_token", "logs_file_path", "grpc_do_verify_ssl"),
 )
 
 
@@ -17,6 +18,7 @@ def _get_channel_config(url: str) -> _ChannelConfig:
         grpc_gateway_address=url,
         access_token="",
         logs_file_path=LogsConfig().logs_file_path,
+        grpc_do_verify_ssl=True,
     )
 
 

--- a/layer/utils/grpc/channel.py
+++ b/layer/utils/grpc/channel.py
@@ -87,7 +87,7 @@ def grpc_single_channel(channel_factory: Callable[..., Any]) -> Callable[..., An
             channel.append(channel_factory(*args, **kwargs))
         else:
             if closing:
-                # do not memoize the channel if it is being closed
+                # do not memoize the channel anymore if it is being closed
                 return channel.pop()
 
         return channel[0]

--- a/layer/utils/grpc/channel.py
+++ b/layer/utils/grpc/channel.py
@@ -70,7 +70,7 @@ def create_grpc_channel(
     )
 
 
-def grpc_single_channel(channel_factory: Callable[..., Any]) -> Callable[..., Any]:
+def _grpc_single_channel(channel_factory: Callable[..., Any]) -> Callable[..., Any]:
     """Maintains a single GRPC channel for all client calls."""
 
     channel: List[Any] = []  # a pool for the channel
@@ -95,7 +95,7 @@ def grpc_single_channel(channel_factory: Callable[..., Any]) -> Callable[..., An
     return _get_grpc_channel
 
 
-@grpc_single_channel
+@_grpc_single_channel
 def get_grpc_channel(client_config: Any) -> Any:
     return create_grpc_channel(
         address=client_config.grpc_gateway_address,

--- a/test/unit/decorators/util.py
+++ b/test/unit/decorators/util.py
@@ -1,5 +1,4 @@
 import contextlib
-import logging
 from typing import Optional
 from unittest.mock import MagicMock, patch
 from uuid import UUID
@@ -58,10 +57,7 @@ VALID_UUID = UUID(int=0x12345678123456781234567812345678)
 def _get_mock_project_service_client(
     project_api_stub: Optional[MagicMock] = None,
 ) -> ProjectServiceClient:
-    config_mock = MagicMock(spec=ClientConfig)
-    project_client = ProjectServiceClient(
-        config=config_mock, logger=MagicMock(spec_set=logging.getLogger())
-    )
+    project_client = ProjectServiceClient()
     if project_api_stub is None:
         valid_response = Project(
             id=VALID_UUID,

--- a/test/unit/logged_data/util.py
+++ b/test/unit/logged_data/util.py
@@ -1,18 +1,13 @@
-import logging
 from typing import Optional
 from unittest.mock import MagicMock
 
 from layer.clients.logged_data_service import LoggedDataClient
-from layer.config import ClientConfig
 
 
 def get_logged_data_service_client_with_mocks(
     logged_data_api_stub: Optional[MagicMock] = None,
 ) -> LoggedDataClient:
-    config_mock = MagicMock(spec=ClientConfig)
-    logged_data_client = LoggedDataClient(
-        config=config_mock, logger=MagicMock(spec_set=logging.getLogger())
-    )
+    logged_data_client = LoggedDataClient()
     logged_data_client._service = (  # pylint: disable=protected-access
         logged_data_api_stub if logged_data_api_stub is not None else MagicMock()
     )

--- a/test/unit/projects/test_projects_service_client.py
+++ b/test/unit/projects/test_projects_service_client.py
@@ -1,4 +1,3 @@
-import logging
 import uuid
 from typing import Optional
 from unittest.mock import MagicMock
@@ -16,7 +15,6 @@ from layerapi.api.service.flowmanager.project_api_pb2 import (
 )
 
 from layer.clients.project_service import ProjectServiceClient
-from layer.config import ClientConfig
 from layer.contracts.project_full_name import ProjectFullName
 from layer.exceptions.exceptions import (
     LayerClientException,
@@ -27,10 +25,7 @@ from layer.exceptions.exceptions import (
 def _get_project_service_client_with_mocks(
     project_api_stub: Optional[MagicMock] = None,
 ) -> ProjectServiceClient:
-    config_mock = MagicMock(spec=ClientConfig)
-    project_service_client = ProjectServiceClient(
-        config=config_mock, logger=MagicMock(spec_set=logging.getLogger())
-    )
+    project_service_client = ProjectServiceClient()
     # can"t use spec_set as it does not recognise methods as defined by protocompiler
     project_service_client._service = (  # pylint: disable=protected-access
         project_api_stub if project_api_stub is not None else MagicMock()

--- a/test/unit/test_dataset.py
+++ b/test/unit/test_dataset.py
@@ -112,7 +112,6 @@ def _dataset_client_mock(dataset_client_mock=None):
     data_catalog_client = DataCatalogClient(
         config=MagicMock(),
         logger=MagicMock(),
-        flight_client=MagicMock(),
         dataset_client=dataset_client,
     )
 


### PR DESCRIPTION
There's a common pattern throughout the SDK to call an operation on the backend:

```python
with LayerClient(config.client, logger).init() as client:
    # call list datasets
    client.data_catalog.list_datasets()
```

However, such snippet opens 10 SSL connections each time it is executed!

```bash
GRPC_VERBOSITY=debug GRPC_TRACE=all python ~/layer/1/layer_init.py 2>&1 | grep "grpc_secure_channel_create"
I0721 11:53:22.103882000 8644068864 chttp2_connector.cc:395]           grpc_secure_channel_create(target=grpc.development.layer.co:443, creds=0x6000023b83c0, args=0x307238730)
I0721 11:53:22.107976000 8644068864 chttp2_connector.cc:371]           grpc_secure_channel_create(target=grpc.development.layer.co:443, creds=0x6000036fde00, args=0x7febda1b7a40)
I0721 11:53:22.109439000 8644068864 chttp2_connector.cc:371]           grpc_secure_channel_create(target=grpc.development.layer.co:443, creds=0x6000036fdd60, args=0x7febda218320)
I0721 11:53:22.109635000 8644068864 chttp2_connector.cc:371]           grpc_secure_channel_create(target=grpc.development.layer.co:443, creds=0x6000036fd660, args=0x7febda2182c0)
I0721 11:53:22.109762000 8644068864 chttp2_connector.cc:371]           grpc_secure_channel_create(target=grpc.development.layer.co:443, creds=0x6000036fd860, args=0x7febda218320)
I0721 11:53:22.109978000 8644068864 chttp2_connector.cc:371]           grpc_secure_channel_create(target=grpc.development.layer.co:443, creds=0x6000036fdca0, args=0x7febda2182c0)
I0721 11:53:22.110114000 8644068864 chttp2_connector.cc:371]           grpc_secure_channel_create(target=grpc.development.layer.co:443, creds=0x6000036fd880, args=0x7febda218320)
I0721 11:53:22.110248000 8644068864 chttp2_connector.cc:371]           grpc_secure_channel_create(target=grpc.development.layer.co:443, creds=0x6000036feda0, args=0x7febda2184a0)
I0721 11:53:22.110379000 8644068864 chttp2_connector.cc:371]           grpc_secure_channel_create(target=grpc.development.layer.co:443, creds=0x6000036fdd80, args=0x7febda218440)
I0721 11:53:22.110492000 8644068864 chttp2_connector.cc:371]           grpc_secure_channel_create(target=grpc.development.layer.co:443, creds=0x6000036fef60, args=0x7febda2184a0)
```

Moreover, since client is closed after being used, it leaves 10 connections in a `TIME_WAIT` state, which consumes the precious file descriptors for a while (and there's a limit for them).

Such way of connecting to gRPC is degrading the performance on client and server sides.

Following the [best practices of gRPC](https://grpc.io/docs/guides/performance/#general), single channel per process is always enough.