### PR TITLE
Layer function runtime for dataset builds

### DIFF
--- a/layer/clients/data_catalog.py
+++ b/layer/clients/data_catalog.py
@@ -223,11 +223,11 @@ class DataCatalogClient:
         asset_path: AssetPath,
         project_id: uuid.UUID,
         description: str,
-        function_home_dir: Path,
         fabric: str,
         func_source: str,
         entrypoint: str,
         environment: str,
+        function_home_dir: Optional[Path] = None,
     ) -> str:
         self._logger.debug(
             "Adding or updating a dataset with name %r",
@@ -239,11 +239,11 @@ class DataCatalogClient:
                 description=description,
                 python_dataset=self._get_pb_python_dataset(
                     asset_path,
-                    function_home_dir,
                     fabric,
                     func_source,
                     entrypoint,
                     environment,
+                    function_home_dir,
                 ),
                 project_id=ProjectId(value=str(project_id)),
             ),
@@ -253,13 +253,17 @@ class DataCatalogClient:
     def _get_pb_python_dataset(
         self,
         asset_path: AssetPath,
-        function_home_dir: Path,
         fabric: str,
         func_source: str,
         entrypoint: str,
         environment: str,
+        function_home_dir: Optional[Path] = None,
     ) -> PBPythonDataset:
-        s3_path = self._upload_dataset_source(asset_path, function_home_dir)
+        s3_path = (
+            self._upload_dataset_source(asset_path, function_home_dir)
+            if function_home_dir
+            else None
+        )
         language_version = _language_version()
         return PBPythonDataset(
             s3_path=s3_path,

--- a/layer/executables/layer_runtime.py
+++ b/layer/executables/layer_runtime.py
@@ -1,0 +1,9 @@
+from layer.executables.runtime import BaseFunctionRuntime
+
+
+class LayerFunctionRuntime(BaseFunctionRuntime):
+    pass
+
+
+if __name__ == "__main__":
+    LayerFunctionRuntime.main()

--- a/layer/executables/layer_runtime.py
+++ b/layer/executables/layer_runtime.py
@@ -1,9 +1,151 @@
+import logging
+import os
+import uuid
+from argparse import ArgumentParser
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from layerapi.api.ids_pb2 import ProjectId
+
+import layer
+from layer.clients.data_catalog import DataCatalogClient
+from layer.clients.project_service import ProjectServiceClient
+from layer.config.config import ClientConfig
+from layer.config.config_manager import ConfigManager
+from layer.contracts.asset import AssetPath, AssetType
+from layer.contracts.fabrics import Fabric
+from layer.executables.packager import FunctionPackageInfo
 from layer.executables.runtime import BaseFunctionRuntime
+from layer.global_context import current_project_full_name, set_has_shown_update_message
+
+
+_ProjectId = uuid.UUID
+
+_ENV_LAYER_API_URL = "LAYER_API_URL"
+_ENV_LAYER_API_KEY = "LAYER_API_KEY"
 
 
 class LayerFunctionRuntime(BaseFunctionRuntime):
+    def __init__(
+        self,
+        executable_path: Path,
+        project: str,
+        api_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ) -> None:
+        super().__init__(executable_path)
+        self._project = project
+        self._logger = logging.getLogger("layer.runtime")
+        self._api_url: Optional[str] = api_url or os.environ.get(_ENV_LAYER_API_URL)
+        self._api_key: Optional[str] = api_key or os.environ.get(_ENV_LAYER_API_KEY)
+        self._package_info: Optional[FunctionPackageInfo] = None
+        self._project_id: Optional[_ProjectId] = None
+        self._client_config: Optional[ClientConfig] = None
+
+    def initialise(self, package_info: FunctionPackageInfo) -> None:
+        self._package_info = package_info
+
+        # setup client config
+        if self._api_url and self._api_key:
+            layer.login_with_api_key(self._api_key, url=self._api_url)
+
+        self._client_config = ConfigManager().load().client
+
+        # required to ensure project exists
+        self._layer_init()
+        self._project_id = self._get_project_id()
+
+    def __call__(self, func: Callable[..., Any]) -> Any:
+        function_output = _get_function_output(self._package_info.metadata)  # type: ignore
+        if function_output.is_dataset:
+            self._create_dataset(function_output.name, func)
+        else:
+            raise LayerFunctionRuntimeError(
+                f"unsupported function output type: {function_output.type}"
+            )
+
+    def _layer_init(self) -> None:
+        set_has_shown_update_message(shown=True)
+        layer.init(project_name=self._project)
+
+    def _get_project_id(self) -> _ProjectId:
+        projects = ProjectServiceClient.create(self._client_config)  # type: ignore
+        project_name = (
+            current_project_full_name()
+        )  # project is always set in the context by layer.init
+        project = projects.get_project(project_name)  # type: ignore
+        if project is None:
+            raise LayerFunctionRuntimeError(f"project {self._project} does not exist")
+        return project.id
+
+    def _create_dataset(self, name: str, func: Callable[..., Any]) -> None:
+        data_catalog = DataCatalogClient.create(self._client_config, self._logger)  # type: ignore
+        display_fabric = Fabric.F_LOCAL.value  # the fabric to display in the UI
+        asset_path = AssetPath(name, AssetType.DATASET)
+        data_catalog.add_dataset(
+            project_id=self._project_id,  # type: ignore
+            asset_path=asset_path,
+            description="",
+            fabric=display_fabric,
+            func_source="",
+            entrypoint="",
+            environment="",
+        )
+        build_response = data_catalog.initiate_build(
+            ProjectId(value=str(self._project_id)), name, display_fabric
+        )
+        data_catalog.store_dataset(func(), uuid.UUID(build_response.id.value))
+
+
+def _add_cli_args(parser: ArgumentParser) -> None:
+    parser.add_argument(
+        "--project",
+        help="project name",
+        required=True,
+    )
+    parser.add_argument(
+        "--api-url",
+        help=f"api url. Optionally, {_ENV_LAYER_API_URL} environment variable is also supported",
+        required=False,
+    )
+    parser.add_argument(
+        "--api-key",
+        help=f"api key. Optionally, {_ENV_LAYER_API_KEY} environment variable is also supported",
+        required=False,
+    )
+
+
+@dataclass(frozen=True)
+class _FunctionOutput:
+    type: str
+    name: str
+
+    @property
+    def is_dataset(self) -> bool:
+        return self.type == AssetType.DATASET.value
+
+    @property
+    def is_model(self) -> bool:
+        return self.type == AssetType.MODEL.value
+
+
+def _get_function_output(metadata: Dict[str, Any]) -> _FunctionOutput:
+    output = metadata.get("function", {}).get("output")
+    if output is None:
+        raise LayerFunctionRuntimeError("function metadata missing output")
+    type = output.get("type")
+    if type is None:
+        raise LayerFunctionRuntimeError("function metadata missing output type")
+    name = output.get("name")
+    if name is None:
+        raise LayerFunctionRuntimeError("function metadata missing output name")
+    return _FunctionOutput(type, name)
+
+
+class LayerFunctionRuntimeError(Exception):
     pass
 
 
 if __name__ == "__main__":
-    LayerFunctionRuntime.main()
+    LayerFunctionRuntime.main(add_cli_args=_add_cli_args)

--- a/layer/executables/packager.py
+++ b/layer/executables/packager.py
@@ -181,7 +181,7 @@ def _loader_source() -> str:
         def _load_function(function_path):  # type: ignore
             """Loads the cloudpickled function."""
             with open(function_path, mode="rb") as function:
-                return cloudpickle.load(function)  # type: ignore
+                return cloudpickle.load(function)
 
         def _execute():  # type: ignore
             """Extracts the contents of the executable and runs the function in the provided runtime."""

--- a/layer/executables/packager.py
+++ b/layer/executables/packager.py
@@ -144,7 +144,7 @@ def _loader_source() -> str:
         from pathlib import Path
 
         # cloudpickle is included in the executable
-        import cloudpickle  # type: ignore
+        import cloudpickle
 
         def _get_function_runtime():  # type: ignore
             """Load the function runtime from the globals dictionary.
@@ -181,7 +181,7 @@ def _loader_source() -> str:
         def _load_function(function_path):  # type: ignore
             """Loads the cloudpickled function."""
             with open(function_path, mode="rb") as function:
-                return cloudpickle.load(function)
+                return cloudpickle.load(function)  # type: ignore
 
         def _execute():  # type: ignore
             """Extracts the contents of the executable and runs the function in the provided runtime."""

--- a/layer/executables/runtime.py
+++ b/layer/executables/runtime.py
@@ -66,6 +66,22 @@ class BaseFunctionRuntime:
 
         cls.execute(**vars(args))
 
+    @classmethod
+    def main(cls) -> None:
+        from argparse import ArgumentParser
+
+        parser = ArgumentParser(description="Function runtime")
+
+        parser.add_argument(
+            "executable_path",
+            type=Path,
+            help="the local file path of the executable",
+        )
+
+        args = parser.parse_args()
+
+        cls.execute(args.executable_path)
+
 
 def _validate_executable_path(executable_path: Path) -> None:
     if not executable_path:

--- a/layer/executables/runtime.py
+++ b/layer/executables/runtime.py
@@ -66,22 +66,6 @@ class BaseFunctionRuntime:
 
         cls.execute(**vars(args))
 
-    @classmethod
-    def main(cls) -> None:
-        from argparse import ArgumentParser
-
-        parser = ArgumentParser(description="Function runtime")
-
-        parser.add_argument(
-            "executable_path",
-            type=Path,
-            help="the local file path of the executable",
-        )
-
-        args = parser.parse_args()
-
-        cls.execute(args.executable_path)
-
 
 def _validate_executable_path(executable_path: Path) -> None:
     if not executable_path:

--- a/layer/projects/project_runner.py
+++ b/layer/projects/project_runner.py
@@ -262,11 +262,11 @@ def _register_dataset_function(
             dataset.asset_path,
             project_id,
             dataset.description,
-            dataset.function_home_dir,
             dataset.get_fabric(is_local),
             dataset.func_source,
             dataset.entrypoint,
             dataset.environment,
+            dataset.function_home_dir,
         )
         dataset.set_repository_id(uuid.UUID(dataset_id))
         assert dataset.repository_id

--- a/mypy.ini
+++ b/mypy.ini
@@ -31,3 +31,6 @@ ignore_missing_imports = true
 
 [mypy-pyarrow.lib]
 ignore_missing_imports = true
+
+[mypy-cloudpickle]
+ignore_missing_imports = true

--- a/test/e2e/test_layer_runtime.py
+++ b/test/e2e/test_layer_runtime.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+import layer
+from layer import dataset
+from layer.contracts.projects import Project
+from layer.executables.function import Function
+from layer.executables.layer_runtime import LayerFunctionRuntime
+
+
+def test_dataset_build(initialized_project: Project, tmpdir: Path):
+    @dataset("test_dataset")
+    def build_dataset():
+        return pd.DataFrame({"a": [1, 2, 3]})
+
+    function = Function.from_decorated(build_dataset)
+    executable_path = function.package(output_dir=tmpdir)
+    LayerFunctionRuntime.execute(executable_path, project=initialized_project.name)
+
+    actual = layer.get_dataset("test_dataset").to_pandas()
+
+    assert_frame_equal(actual, pd.DataFrame({"a": [1, 2, 3]}))


### PR DESCRIPTION
Layer function runtime for dataset builds. Usage:

```bash
python -m layer.executables.layer_runtime --help
usage: layer_runtime.py [-h] --project PROJECT [--api-url API_URL]
                        [--api-key API_KEY]
                        executable_path

Function runtime

positional arguments:
  executable_path    the local file path of the executable

optional arguments:
  -h, --help         show this help message and exit
  --project PROJECT  project name
  --api-url API_URL  api url. Optionally, LAYER_API_URL environment variable
                     is also supported
  --api-key API_KEY  api key. Optionally, LAYER_API_KEY environment
                     variable is also supported
```