### PR TITLE
INF-1211 Make virtualenv setup easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ venv/
 .vscode/
 
 # make outputs
+.environment.M1.yml
 .install.stamp
 .test-token
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,16 +119,14 @@ This repo uses `make` as the build system. The following targets can be used thr
 ### Python setup
 We recommend using `pyenv`
 
-Please run `pyenv install $(cat .python-version)` in the root of this repository to setup the recommended python version.
+Please run `make create-environment` to setup the recommended python version.
 
-If you are using an M1 machine, we recommend using `conda` via [Miniforge3](https://github.com/conda-forge/miniforge/). Please run
+If you are using an Apple M1 machine, we recommend using `conda` via [Miniforge3](https://github.com/conda-forge/miniforge/). After installing conda please run
 
 ```
-# Install Miniforge3 if required
-/bin/bash -c "$(curl -fsSL https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh)"
 # Create and activate conda environment
-conda create -yq -n sdk python=3.8
-conda activate sdk
+make create-environment
+conda activate build/sdk
 ```
 
 After that you should be able to run the rest of the `make` targets as normal

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ publish: ## Publish to PyPi - should only run in CI
 .PHONY: deepclean
 deepclean: clean ## Resets development environment including test credentials and venv
 	@rm -rf `poetry env info -p`
-	@rm -rf build/$(PROJECT_NAME)
+	@rm -rf build
 	@rm -f $(TEST_TOKEN_FILE)
 
 .PHONY: help

--- a/environment.Makefile
+++ b/environment.Makefile
@@ -1,0 +1,69 @@
+#
+# Environment Management Makefile
+
+define conda_environment_file
+name: sdk\\n
+channels:\\n
+  - default\\n
+  - apple\\n
+  - conda-forge\\n
+dependencies:\\n
+  - python=$(shell cat .python-version)\\n
+  - pip\\n
+  - poetry=$(REQUIRED_POETRY_VERSION)
+endef
+
+.PHONY: create-environment
+create-environment: create-environment-$(UNAME_SYS)
+
+.PHONY: create-environment-Linux
+create-environment-Linux: .python-version
+ifeq ($(shell which pyenv),)
+	@echo "pyenv is not Installed, please install before creating an environment"
+	@exit 1
+else
+	@pyenv install -s $(shell cat $<)
+	@echo "pyenv Python version $(shell cat $<) installed."
+	@echo "Activate shell with poetry shell"
+endif
+
+.PHONY: create-environment-Darwin
+create-environment-Darwin: ## Set up virtual (conda) environment for MacOS
+ifeq ($(UNAME_ARCH), arm64)
+ifdef CONDA_ENV_NAME
+	$(shell echo $(conda_environment_file) > .environment.M1.yml)
+	$(CONDA_EXE) env update -p build/$(PROJECT_NAME) -f .environment.M1.yml
+	@echo
+	@echo "Conda env is available and can be activated."
+else
+	$(error Unsupported Environment. Please use conda)
+endif
+endif
+
+.PHONY: delete-environment
+delete-environment: delete-environment-$(UNAME_SYS)
+
+.PHONY: delete-environment-Linux
+delete-environment-Linux:
+	@echo "No action needed"
+
+.PHONY: delete-environment-Darwin ## Delete the virtual (conda) environment
+delete-environment-Darwin:
+ifeq ($(UNAME_ARCH), arm64)
+	@echo "Deleting conda environment."
+	rm -fr build/$(PROJECT_NAME)
+endif
+
+.PHONY: clean
+clean: ## Resets development environment.
+	@echo 'cleaning repo...'
+	@rm -rf .mypy_cache
+	@rm -rf .pytest_cache
+	@rm -f .coverage
+	@find . -type d -name '*.egg-info' -not -path "*build/$(PROJECT_NAME)/*" | xargs rm -rf {};
+	@find . -depth -type d -name '*.egg-info' -not -path "*build/$(PROJECT_NAME)/*" -delete
+	@rm -rf dist/
+	@rm -f $(INSTALL_STAMP)
+	@find . -type f -name '*.pyc' -not -path "*build/$(PROJECT_NAME)/*" -delete
+	@find . -type d -name "__pycache__" -not -path "*build/$(PROJECT_NAME)/*" | xargs rm -rf {};
+	@echo 'done.'

--- a/include.Makefile
+++ b/include.Makefile
@@ -1,0 +1,13 @@
+ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+INSTALL_STAMP := .install.stamp
+E2E_TEST_HOME := $(ROOT_DIR)/build/e2e-home
+E2E_TEST_SELECTOR := test/e2e
+E2E_TEST_PARALLELISM := 16
+TEST_TOKEN_FILE := .test-token
+POETRY := $(shell command -v poetry 2> /dev/null)
+IN_VENV := $(shell echo $(CONDA_DEFAULT_ENV)$(CONDA_PREFIX)$(VIRTUAL_ENV))
+CONDA_ENV_NAME := $(shell echo $(CONDA_DEFAULT_ENV))
+UNAME_SYS := $(shell uname -s)
+UNAME_ARCH := $(shell uname -m)
+REQUIRED_POETRY_VERSION := 1.1.14
+PROJECT_NAME := sdk


### PR DESCRIPTION
Makes M1 macs work with other conda versions other than miniforge3
Splits Makefile to reduce complexity of one big file
Add a create and remove environment command to help users have a working conda env