### PR TITLE
Fix legacy auth check for account and add account creation / deletion methods to client

### DIFF
--- a/layer/clients/account_service.py
+++ b/layer/clients/account_service.py
@@ -1,9 +1,12 @@
 import uuid
+from typing import Optional
 
+from layerapi.api.entity.account_view_pb2 import AccountView
 from layerapi.api.ids_pb2 import AccountId
 from layerapi.api.service.account.account_api_pb2 import (
+    CreateOrganizationAccountRequest,
+    DeleteAccountRequest,
     GetAccountViewByIdRequest,
-    GetAccountViewByIdResponse,
     GetMyAccountViewRequest,
 )
 from layerapi.api.service.account.account_api_pb2_grpc import AccountAPIStub
@@ -26,18 +29,37 @@ class AccountServiceClient:
         return client
 
     def get_account_name_by_id(self, account_id: uuid.UUID) -> str:
-        get_my_org_resp: GetAccountViewByIdResponse = (
+        account_view: AccountView = (
             self._account_api.GetAccountViewById(
                 GetAccountViewByIdRequest(id=AccountId(value=str(account_id))),
             )
-        )
-        return get_my_org_resp.account_view.name
+        ).account_view
+        return account_view.name
 
     def get_my_account(self) -> Account:
-        account_view = self._account_api.GetMyAccountView(
+        account_view: AccountView = self._account_api.GetMyAccountView(
             GetMyAccountViewRequest(),
         ).account_view
+        return self._account_from_view(account_view)
+
+    def create_organization_account(
+        self, name: str, display_name: Optional[str] = None
+    ) -> Account:
+        account_view: AccountView = self._account_api.CreateOrganizationAccount(
+            CreateOrganizationAccountRequest(
+                name=name, display_name=display_name if display_name else name
+            )
+        ).account_view
+        return self._account_from_view(account_view)
+
+    @staticmethod
+    def _account_from_view(account_view: AccountView) -> Account:
         return Account(
             id=uuid.UUID(account_view.id.value),
             name=account_view.name,
+        )
+
+    def delete_account(self, account_id: uuid.UUID) -> None:
+        self._account_api.DeleteAccount(
+            DeleteAccountRequest(account_id=AccountId(value=str(account_id)))
         )

--- a/layer/config/config.py
+++ b/layer/config/config.py
@@ -137,9 +137,8 @@ class Credentials:
         return self.is_empty or time.time() >= self._access_token_expiration_time
 
     @property
-    def is_authenticated_outside_organization(self) -> bool:
-        # todo: update this to account_id along with LAY-2716
-        return self.is_empty or f"{ROOT_LAYER_URL}/organization_id" not in jwt.decode(
+    def is_authenticated_without_personal_account(self) -> bool:
+        return self.is_empty or f"{ROOT_LAYER_URL}/account_id" not in jwt.decode(
             self.access_token, options={"verify_signature": False}, algorithms=["HS256"]
         )
 

--- a/layer/config/config_manager.py
+++ b/layer/config/config_manager.py
@@ -92,7 +92,7 @@ class ConfigManager:
             )
             creds = await creds_client.request(code)
 
-            if creds.is_authenticated_outside_organization:
+            if creds.is_authenticated_without_personal_account:
                 raise UserWithoutAccountError(config.url)
 
         config = config.with_credentials(creds)


### PR DESCRIPTION
- Authentication check on account should now be done on the new `account_id` jwt claim
- CreateOrganizationAccount and DeleteAccount are needed for e2e test setUp / teardown fixtures