### PR TITLE
Check the hash in the lockfile for change, not the whole lockfile

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,9 +42,11 @@ jobs:
           restore-keys: poetry-vevns-${{ runner.os }}-3.8-
       - name: Check lockfile
         run: |
-          make install
+          pip install yq
+          old_hash=$(cat poetry.lock | tomlq '.metadata["content-hash"]' --raw-output)
           poetry lock --no-update
-          [ -z "$(git status --porcelain=v1 2>/dev/null)" ] || ( git diff && echo "Lock file is not up to date, please run 'poetry cache clear --all pypi' then 'poetry lock --no-update'" && exit 1)
+          new_hash=$(cat poetry.lock | tomlq '.metadata["content-hash"]' --raw-output)
+          [[ "$old_hash" == "$new_hash" ]] || ( git diff && echo "Lock file is not up to date, please run 'poetry cache clear --all pypi' then 'poetry lock --no-update'" && exit 1)
   check:
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,9 +140,11 @@ jobs:
           restore-keys: poetry-venvs-${{ runner.os }}-3.8-
       - name: Check lockfile
         run: |
-          make install
+          pip install yq
+          old_hash=$(cat poetry.lock | tomlq '.metadata["content-hash"]' --raw-output)
           poetry lock --no-update
-          [ -z "$(git status --porcelain=v1 2>/dev/null)" ] || (git diff && echo "Lock file is not up to date, please run 'poetry lock --no-update'" && exit 1)
+          new_hash=$(cat poetry.lock | tomlq '.metadata["content-hash"]' --raw-output)
+          [[ "$old_hash" == "$new_hash" ]] || ( git diff && echo "Lock file is not up to date, please run 'poetry cache clear --all pypi' then 'poetry lock --no-update'" && exit 1)
       - name: Compute package dependencies
         id: deps
         run: |


### PR DESCRIPTION
The `check-lockfile` job has been quite problematic as it naively looks for any changes in the lockfile. However the lockfile is not stable and this keeps failing on PRs that don't touch any dependencies.

Instead check the hash of `pyproject.toml` which is written in the lockfile. This is what poetry uses to print out the warning that the lockfile is not up to date. 

The goal of this check is to ensure that one doesn't change dependencies without updating the lockfile so checking the hash is exactly what we need here.