### PR TITLE
Run layer functions remotely using executables

### DIFF
--- a/layer/clients/executor_service.py
+++ b/layer/clients/executor_service.py
@@ -1,4 +1,7 @@
-from layerapi.api.service.executor.executor_api_pb2 import GetFunctionUploadPathRequest
+from layerapi.api.service.executor.executor_api_pb2 import (
+    GetFunctionDownloadPathRequest,
+    GetFunctionUploadPathRequest,
+)
 from layerapi.api.service.executor.executor_api_pb2_grpc import ExecutorAPIStub
 
 from layer.config import ClientConfig
@@ -16,7 +19,7 @@ class ExecutorClient:
         client._service = ExecutorAPIStub(channel)  # pylint: disable=protected-access
         return client
 
-    def get_upload_path(
+    def get_function_upload_path(
         self,
         project_full_name: ProjectFullName,
         function_name: str,
@@ -26,3 +29,16 @@ class ExecutorClient:
             function_name=function_name,
         )
         return self._service.GetFunctionUploadPath(request=request).function_upload_path
+
+    def get_function_download_path(
+        self,
+        project_full_name: ProjectFullName,
+        function_name: str,
+    ) -> str:
+        request = GetFunctionDownloadPathRequest(
+            project_full_name=project_full_name.path,
+            function_name=function_name,
+        )
+        return self._service.GetFunctionDownloadPath(
+            request=request
+        ).function_download_path

--- a/layer/executables/function.py
+++ b/layer/executables/function.py
@@ -63,6 +63,10 @@ class Function:
         )
 
     @property
+    def name(self) -> str:
+        return self._func.__name__
+
+    @property
     def func(self) -> Callable[..., Any]:
         return self._func
 

--- a/layer/executables/runner.py
+++ b/layer/executables/runner.py
@@ -1,0 +1,130 @@
+import asyncio
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+import aiohttp
+from layerapi.api.entity.operations_pb2 import (
+    ExecutionPlan,
+    FunctionExecutionOperation,
+    Operation,
+    SequentialOperation,
+)
+from layerapi.api.entity.task_pb2 import Task
+from layerapi.api.ids_pb2 import RunId
+
+from layer.clients.executor_service import ExecutorClient
+from layer.clients.flow_manager import FlowManagerClient
+from layer.config.config_manager import ConfigManager
+from layer.contracts.project_full_name import ProjectFullName
+from layer.contracts.runs import Run
+from layer.executables.function import DatasetOutput, Function, ModelOutput
+from layer.projects.utils import get_current_project_full_name
+
+
+def remote_run(funcs: Sequence[Callable[..., Any]]) -> Run:
+    job = _Job.from_functions(funcs)
+    project = get_current_project_full_name()
+
+    client_config = ConfigManager().load().client
+    executor_client = ExecutorClient.create(client_config)
+    flow_manager_client = FlowManagerClient.create(client_config)
+    remote_runner = _RemoteRunner(executor_client, flow_manager_client, project)
+
+    run_id = remote_runner.submit_job(job)
+
+    return Run(run_id, project)
+
+
+@dataclass(frozen=True)
+class _Job:
+    functions: Sequence[Function]
+
+    @staticmethod
+    def from_functions(functions: Sequence[Callable[..., Any]]) -> "_Job":
+        return _Job(functions=tuple(Function.from_decorated(f) for f in functions))
+
+
+class _RemoteRunner:
+    def __init__(
+        self,
+        executor_client: ExecutorClient,
+        flow_manager_client: FlowManagerClient,
+        project: ProjectFullName,
+    ) -> None:
+        self._flow_manager_client = flow_manager_client
+        self._executor_client = executor_client
+        self._project = project
+
+    def submit_job(self, job: _Job) -> RunId:
+        # submit job in a separate thread pool, to get own asyncio event loop
+        with ThreadPoolExecutor(max_workers=1) as executor:
+
+            def asyncio_run() -> RunId:
+                return asyncio.run(self._submit_job(job))
+
+            run_id = executor.submit(asyncio_run)
+            return run_id.result(timeout=None)
+
+    async def _submit_job(self, job: _Job) -> RunId:
+        async with aiohttp.ClientSession(raise_for_status=True) as session:
+            upload_tasks = (self._upload_function(session, f) for f in job.functions)
+            await asyncio.gather(*upload_tasks)
+
+        # execute each function sequentially
+        execution_plan = self._sequential_execution_plan(job)
+
+        run_id = self._flow_manager_client.start_run(
+            project_full_name=self._project,
+            execution_plan=execution_plan,
+            project_files_hash="73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049",  # TODO: check if checksum is used
+            user_command="",
+        )
+
+        return run_id
+
+    async def _upload_function(
+        self, session: aiohttp.ClientSession, function: Function
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            package_path = function.package(output_dir=Path(temp_dir))
+            package_uri = self._executor_client.get_function_upload_path(
+                self._project, function.name
+            )
+            with open(package_path, mode="rb") as f:
+                async with session.put(
+                    package_uri, data=f, timeout=aiohttp.ClientTimeout(total=None)
+                ):
+                    pass
+
+    def _sequential_execution_plan(self, job: _Job) -> ExecutionPlan:
+        operations = tuple(
+            Operation(
+                sequential=SequentialOperation(
+                    function_execution=self._function_to_execution_operation(f)
+                )
+            )
+            for f in job.functions
+        )
+
+        return ExecutionPlan(operations=operations)
+
+    def _function_to_execution_operation(
+        self, function: Function
+    ) -> FunctionExecutionOperation:
+        task_type = Task.Type.TYPE_INVALID
+        if isinstance(function.output, DatasetOutput):
+            task_type = Task.Type.TYPE_DATASET_BUILD
+        elif isinstance(function.output, ModelOutput):
+            task_type = Task.Type.TYPE_MODEL_TRAIN
+
+        return FunctionExecutionOperation(
+            task_type=task_type,
+            asset_name=function.output.name,
+            executable_package_url=self._executor_client.get_function_download_path(
+                self._project, function.name
+            ),
+            fabric=function.fabric.value,
+        )

--- a/layer/main.py
+++ b/layer/main.py
@@ -26,7 +26,12 @@ from layer import Image, Markdown
 from layer.cache.cache import Cache
 from layer.cache.utils import is_cached
 from layer.clients.layer import LayerClient
-from layer.config import DEFAULT_PATH, DEFAULT_URL, ConfigManager
+from layer.config import (
+    DEFAULT_PATH,
+    DEFAULT_URL,
+    ConfigManager,
+    is_executables_feature_active,
+)
 from layer.config.config import Config
 from layer.context import Context
 from layer.contracts.assets import AssetPath, AssetType
@@ -549,7 +554,10 @@ def init(
 
 
 def run(
-    functions: List[Any], debug: bool = False, ray_address: Optional[str] = None
+    functions: List[Any],
+    debug: bool = False,
+    ray_address: Optional[str] = None,
+    **kwargs: Any,
 ) -> Run:
     """
     :param functions: List of decorated functions to run in the Layer backend.
@@ -582,6 +590,11 @@ def run(
         run = layer.run([create_my_dataset])
         # run = layer.run([create_my_dataset], debug=True)  # Stream logs to console
     """
+    if kwargs.get("executables_feature", False) or is_executables_feature_active():
+        from layer.executables.runner import remote_run
+
+        return remote_run(functions)
+
     _check_python_version()
     _ensure_all_functions_are_decorated(functions)
 

--- a/layer/projects/project_runner.py
+++ b/layer/projects/project_runner.py
@@ -179,7 +179,7 @@ class ProjectRunner:
         session: aiohttp.ClientSession,
     ) -> None:
         with open(function.executable_path, "rb") as package_file:
-            presigned_url = client.executor_service_client.get_upload_path(
+            presigned_url = client.executor_service_client.get_function_upload_path(
                 project_full_name=self.project_full_name,
                 function_name=function.func.__name__,
             )

--- a/test/e2e/test_remote_run.py
+++ b/test/e2e/test_remote_run.py
@@ -1,0 +1,20 @@
+from layer.contracts.projects import Project
+from layer.decorators.dataset_decorator import dataset
+from layer.decorators.model_decorator import model
+from layer.executables.runner import remote_run
+
+
+def test_remote_submit(initialized_project: Project):
+    @dataset("d")
+    def d():
+        return [1]
+
+    @model("m")
+    def m():
+        return [2]
+
+    run = remote_run([d, m])
+
+    assert run
+    assert len(run.id.value) > 0
+    assert run.project_full_name == initialized_project.full_name

--- a/test/unit/executables/test_runner.py
+++ b/test/unit/executables/test_runner.py
@@ -1,0 +1,30 @@
+import os
+from unittest.mock import patch
+
+import layer
+from layer.decorators.dataset_decorator import dataset
+from layer.decorators.model_decorator import model
+
+
+def test_remote_run_executables_feature_flag_arg_passed():
+    with patch("layer.executables.runner.remote_run") as remote_run:
+        layer.run(functions=[d, m], executables_feature=True)
+        remote_run.assert_called_once_with([d, m])
+
+
+def test_remote_run_executables_feature_flag_env_var():
+    with patch.dict(os.environ, {"LAYER_EXECUTABLES": "1"}), patch(
+        "layer.executables.runner.remote_run"
+    ) as remote_run:
+        layer.run(functions=[d, m])
+        remote_run.assert_called_once_with([d, m])
+
+
+@dataset("d")
+def d():
+    return [1]
+
+
+@model("m")
+def m():
+    return [2]


### PR DESCRIPTION
Run layer functions remotely using executable packages.

The feature is not yet enabled and requires passing a feature flag to `layer.run(..., executables_feature=True)` or setting the environment variable `LAYER_EXECUTABLES=1` for the process.

Example:

```python
import layer
import pandas as pd
from layer.decorators import dataset, model


@dataset("dummy-dataset")
def build_dataset():
    return pd.DataFrame({"a": [1, 2, 42]})


@model("dummy-model")
def train_model():
    from sklearn.datasets import make_classification
    from sklearn.ensemble import RandomForestClassifier

    X, y = make_classification(
        n_samples=1000,
        n_features=4,
        n_informative=2,
        n_redundant=0,
        random_state=0,
        shuffle=False,
    )

    classifier = RandomForestClassifier(max_depth=2, random_state=0)
    return classifier.fit(X, y)


layer.init("layer/layer-runtime-101")
run_id = layer.run(functions=[build_dataset, train_model], executables_feature=True)

print(run_id)
```