### PR TITLE
INF-1226: cache install and prereqs correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ ipython.magic("autoreload 2")
 endef
 export autoreloadpy
 
-install: $(INSTALL_STAMP) ## Install dependencies
-$(INSTALL_STAMP): pyproject.toml poetry.lock .python-version prereq-$(UNAME_SYS) check-poetry
+install: $(INSTALL_STAMP) check-poetry ## Install dependencies
+$(INSTALL_STAMP): pyproject.toml poetry.lock $(PREREQ_STAMP)
 ifdef IN_VENV
 	$(POETRY) install
 else
@@ -26,32 +26,7 @@ else
 endif
 	@poetry run ipython profile create --ipython-dir=build/ipython
 	@echo "$$autoreloadpy" > build/ipython/profile_default/startup/00-autoreload.py
-	touch $(INSTALL_STAMP)
-
-.PHONY: prereq-Linux
-prereq-Linux:
-
-.PHONY: prereq-Darwin
-prereq-Darwin:
-ifeq ($(UNAME_ARCH), arm64)
-ifdef CONDA_ENV_NAME
-ifeq ($(CONDA_ENV_NAME), base)
-	@echo 'Please create a conda environment and make it active'
-	@exit 1
-else
-	echo "installing conda deps"
-	@conda install -y $(call get_python_package_version,tokenizers) \
-                         $(call get_python_package_version,xgboost) \
-                         $(call get_python_package_version,lightgbm) \
-                         $(call get_python_package_version,h5py) \
-                         $(call get_python_package_version,pyarrow)
-endif
-else
-	@echo 'Not inside a conda environment or conda not installed, this is a requirement for Apple arm processors'
-	@echo 'See https://github.com/conda-forge/miniforge/'
-	@exit 1
-endif
-endif
+	@touch $(INSTALL_STAMP)
 
 .PHONY: test
 test: $(INSTALL_STAMP) ## Run unit tests

--- a/environment.mk
+++ b/environment.mk
@@ -15,6 +15,7 @@ endef
 
 .PHONY: create-environment
 create-environment: create-environment-$(UNAME_SYS) ## Set up python environment
+	@rm -rf $(PYTHON_ENV_STAMP_DIR)
 
 .PHONY: create-environment-Linux
 create-environment-Linux: .python-version
@@ -54,6 +55,33 @@ ifeq ($(UNAME_ARCH), arm64)
 	rm -fr build/$(PROJECT_NAME)
 endif
 
+$(PYTHON_ENV_STAMP):
+	@rm -rf $(PYTHON_ENV_STAMP_DIR_CURRENT)
+	@mkdir -p $(PYTHON_ENV_STAMP_DIR_CURRENT)
+	@touch $(PYTHON_ENV_STAMP)
+
+$(PREREQ_STAMP): $(PYTHON_ENV_STAMP)
+ifeq ($(UNAME_ARCH), arm64)
+ifdef CONDA_ENV_NAME
+ifeq ($(CONDA_ENV_NAME), base)
+	@echo 'Please create a conda environment and make it active'
+	@exit 1
+else
+	echo "installing conda deps"
+	@conda install -y $(call get_python_package_version,tokenizers) \
+                         $(call get_python_package_version,xgboost) \
+                         $(call get_python_package_version,lightgbm) \
+                         $(call get_python_package_version,h5py) \
+                         $(call get_python_package_version,pyarrow)
+endif
+else
+	@echo 'Not inside a conda environment or conda not installed, this is a requirement for Apple arm processors'
+	@echo 'See https://github.com/conda-forge/miniforge/'
+	@exit 1
+endif
+endif
+	@touch $(PREREQ_STAMP)
+
 .PHONY: jupyter
 jupyter: install ## Start a jupyter notebook with editable layer package
 	@IPYTHONDIR=$(ROOT_DIR)/build/ipython poetry run jupyter-notebook
@@ -71,4 +99,5 @@ clean: ## Resets development environment.
 	@rm -f $(COLAB_IMAGE_BUILD_STAMP)
 	@find . -type f -name '*.pyc' -not -path "*build/$(PROJECT_NAME)/*" -delete
 	@find . -type d -name "__pycache__" -not -path "*build/$(PROJECT_NAME)/*" | xargs rm -rf {};
+	@rm -rf $(OUTPUTS_DIR)
 	@echo 'done.'

--- a/include.mk
+++ b/include.mk
@@ -1,5 +1,4 @@
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-INSTALL_STAMP := .install.stamp
 E2E_TEST_HOME := $(ROOT_DIR)/build/e2e-home
 E2E_TEST_SELECTOR := test/e2e
 E2E_TEST_PARALLELISM := 16
@@ -14,4 +13,11 @@ PROJECT_NAME := sdk
 COLAB_TEST_HOME := $(ROOT_DIR)/build/colab-test
 COLAB_IMAGE_BUILD_STAMP := .image-built.stamp
 DOCKER_IMAGE_NAME = layerco/colab-lite
-
+OUTPUTS_DIR := $(ROOT_DIR)/build/outputs
+PYTHON_ENV_STAMP_DIR := $(OUTPUTS_DIR)/python-env-stamps
+PYTHON_ENV_STAMP_PYTHON_PATH := $(shell which python | tr -d '\n')
+PYTHON_VERSION := $(shell python --version | tr -d '\n' | sed 's/ //g')
+PYTHON_ENV_STAMP_DIR_CURRENT := $(PYTHON_ENV_STAMP_DIR)$(PYTHON_ENV_STAMP_PYTHON_PATH)/$(PYTHON_VERSION)
+PYTHON_ENV_STAMP := $(PYTHON_ENV_STAMP_DIR_CURRENT)/.python.stamp
+PREREQ_STAMP := $(PYTHON_ENV_STAMP_DIR_CURRENT)/.prereq.stamp
+INSTALL_STAMP := $(PYTHON_ENV_STAMP_DIR_CURRENT)/.install.stamp


### PR DESCRIPTION
We currently have an issue that we always run `poetry install` before any command. This takes up to 30s to do nothing :(

This implements a convoluted way to cache this and invalidate the cache when the python environment changes. It uses a path of the form `build/outputs/{python-path}/{python-version}/` and stores the stamps for `poetry install` and `prereq` which both install dependencies into the environment.
