### PR TITLE
Execute layer runtime locally

### DIFF
--- a/layer/decorators/dataset_decorator.py
+++ b/layer/decorators/dataset_decorator.py
@@ -144,8 +144,10 @@ def _dataset_wrapper(
         # See https://layerco.slack.com/archives/C02R5B3R3GU/p1646144705414089 for detail.
         def __call__(self, *args: Any, **kwargs: Any) -> Any:
             if is_executables_feature_active():
-                # execute the function, metadata capture will be done by the runtime
-                return self.__wrapped__(*args, **kwargs)
+                from layer.executables.layer_runtime import local_run
+
+                return local_run(self)
+
             self.layer.validate()
             dataset_definition = self.get_definition()
             dataset_definition.package()

--- a/layer/decorators/model_decorator.py
+++ b/layer/decorators/model_decorator.py
@@ -111,8 +111,10 @@ def _model_wrapper(
         # See https://layerco.slack.com/archives/C02R5B3R3GU/p1646144705414089 for detail.
         def __call__(self, *args: Any, **kwargs: Any) -> Any:
             if is_executables_feature_active():
-                # execute the function, metadata capture will be done by the runtime
-                return self.__wrapped__(*args, **kwargs)
+                from layer.executables.layer_runtime import local_run
+
+                return local_run(self)
+
             model_definition = self.get_definition()
             model_definition.package()
             config: Config = asyncio_run_in_thread(ConfigManager().refresh())

--- a/layer/exceptions/exceptions.py
+++ b/layer/exceptions/exceptions.py
@@ -97,7 +97,10 @@ class ProjectBaseException(Exception):
         return self.suggestion
 
     def _format_message(self) -> str:
-        return f"Error: {self._error_msg},\nSuggestion: {self._suggestion}"
+        message = f"Error: {self._error_msg}"
+        if self._suggestion:
+            message += f",\nSuggestion: {self._suggestion}"
+        return message
 
 
 class ProjectExecutionException(ProjectBaseException):

--- a/layer/executables/packager.py
+++ b/layer/executables/packager.py
@@ -210,7 +210,9 @@ def _loader_source() -> str:
                     _extract_function(exec, function_path)  # type: ignore
 
                 function = _load_function(function_path)  # type: ignore
-                runtime_exec(function)
+
+                # set the returned result to exchange with the local runtime
+                globals()["__function_return_result"] = runtime_exec(function)
 
         _execute()  # type: ignore
 

--- a/layer/executables/runtime.py
+++ b/layer/executables/runtime.py
@@ -34,16 +34,14 @@ class BaseFunctionRuntime:
 
     def run_executable(self) -> Any:
         """Runs the packaged function."""
-        runpy.run_path(
+        return runpy.run_path(
             str(self.executable_path),
             run_name="__main__",
             init_globals={"__function_runtime": self},
-        )
+        ).get("__function_return_result", None)
 
     @classmethod
-    def execute(
-        cls, executable_path: ExecutablePath, *args: Any, **kwargs: Any
-    ) -> None:
+    def execute(cls, executable_path: ExecutablePath, *args: Any, **kwargs: Any) -> Any:
         """Initialises the environment, installs packages and runs the executable."""
         local_executable_path = _get_local_executable_path(executable_path)
         _validate_executable_path(local_executable_path)
@@ -51,7 +49,7 @@ class BaseFunctionRuntime:
         runtime = cls(local_executable_path, *args, **kwargs)
         runtime.initialise(package_info)
         runtime.install_packages(packages=package_info.pip_dependencies)
-        runtime.run_executable()
+        return runtime.run_executable()
 
     @classmethod
     def main(

--- a/test/e2e/test_layer_runtime.py
+++ b/test/e2e/test_layer_runtime.py
@@ -1,4 +1,6 @@
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pandas as pd
 from pandas.testing import assert_frame_equal
@@ -51,3 +53,47 @@ def test_model_trains(initialized_project: Project, tmpdir: Path):
 
     assert actual_model
     assert actual_model.predict([[0, 0, 0, 0]]).to_dict() == {0: {0: 1}}
+
+
+def test_dataset_build_local_run(initialized_project: Project, tmpdir: Path):
+    @dataset("test_dataset_local")
+    def build_dataset():
+        return pd.DataFrame({"a": [1, 2, 3]})
+
+    expected_dataset = pd.DataFrame({"a": [1, 2, 3]})
+
+    with patch.dict(os.environ, {"LAYER_EXECUTABLES": "1"}):
+        assert_frame_equal(build_dataset(), expected_dataset)
+
+    fetched_dataset = layer.get_dataset("test_dataset_local").to_pandas()
+
+    assert_frame_equal(fetched_dataset, expected_dataset)
+
+
+def test_model_trains_local_run(initialized_project: Project, tmpdir: Path):
+    @model("test_model_local")
+    def train_model():
+        from sklearn.datasets import make_classification
+        from sklearn.ensemble import RandomForestClassifier
+
+        X, y = make_classification(
+            n_samples=1000,
+            n_features=4,
+            n_informative=2,
+            n_redundant=0,
+            random_state=0,
+            shuffle=False,
+        )
+
+        classifier = RandomForestClassifier(max_depth=2, random_state=0)
+
+        return classifier.fit(X, y)
+
+    with patch.dict(os.environ, {"LAYER_EXECUTABLES": "1"}):
+        trained_model = train_model()
+        assert trained_model.predict([[0, 0, 0, 0]]) == [1]
+
+    fetched_model = layer.get_model("test_model_local")
+
+    assert fetched_model
+    fetched_model.predict([[0, 0, 0, 0]]).to_dict() == {0: {0: 1}}


### PR DESCRIPTION
Execute the same `layer_runtime` module for local runs.

Add the `__function_return_result` name to function package Python namespace to exchange the function return result with the runtime. It is safe to do so, as `__function_return_result` is isolated within the function package module and does not pollute the namespace of the main process.

The code is guarded by the `LAYER_EXECUTABLES=1` environment variable condition and is not executed by default.