### PR TITLE
Make models optional to return from the model decorator

### DIFF
--- a/layer/__init__.py
+++ b/layer/__init__.py
@@ -22,7 +22,7 @@ from .decorators.assertions import (  # noqa
 from .flavors.custom import CustomModel  # noqa
 from .global_context import current_project_full_name  # noqa
 from .logged_data.callbacks import KerasCallback, XGBoostCallback  # noqa
-from .main.asset import get_dataset, get_model  # noqa
+from .main.asset import get_dataset, get_model, save_model  # noqa
 from .main.auth import (  # noqa
     login,
     login_as_guest,

--- a/layer/clients/model_catalog.py
+++ b/layer/clients/model_catalog.py
@@ -45,7 +45,7 @@ from layer.contracts.tracker import ResourceTransferState
 from layer.exceptions.exceptions import LayerClientException
 from layer.flavors.base import ModelRuntimeObjects
 from layer.flavors.utils import get_flavor_for_proto
-from layer.tracker.ui_progress_tracker import UIRunProgressTracker
+from layer.tracker.progress_tracker import RunProgressTracker
 from layer.utils.grpc.channel import get_grpc_channel
 from layer.utils.s3 import S3Util
 
@@ -218,7 +218,7 @@ class ModelCatalogClient:
         self,
         model: Model,
         model_object: ModelObject,
-        tracker: UIRunProgressTracker,
+        tracker: RunProgressTracker,
     ) -> ModelObject:
         self._logger.debug(f"Storing given model {model_object} for {model.path}")
         try:

--- a/layer/main/asset.py
+++ b/layer/main/asset.py
@@ -279,3 +279,31 @@ def _ensure_asset_path_is_absolute(
         ProjectFullName(account_name=account_name, project_name=project_name)
     )
     return path
+
+
+@sdk_function
+def save_model(model: Any) -> None:
+    """
+    :param model: The model object to save.
+    :return: None.
+
+    Saves a model object to Layer under the currently decorated function.
+
+    .. code-block:: python
+
+        # Loads the default version of the model.
+        my_model = train()
+        layer.save_model(my_model)
+    """
+    active_context = get_active_context()
+    if not active_context:
+        raise RuntimeError(
+            "Saving model only allowed inside functions decorated with @model"
+        )
+    train = active_context.train()
+    tracker = active_context.tracker()
+    if not train or not tracker:
+        raise RuntimeError(
+            "Saving model only allowed inside functions decorated with @model"
+        )
+    train.save_model(model, tracker=tracker)

--- a/layer/main/asset.py
+++ b/layer/main/asset.py
@@ -291,7 +291,7 @@ def save_model(model: Any) -> None:
 
     .. code-block:: python
 
-        # Loads the default version of the model.
+        # Saves the model to the current train.
         my_model = train()
         layer.save_model(my_model)
     """

--- a/layer/training/base_train.py
+++ b/layer/training/base_train.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-from layer.tracker.ui_progress_tracker import UIRunProgressTracker
+from layer.tracker.progress_tracker import RunProgressTracker
 
 
 if TYPE_CHECKING:
@@ -36,7 +36,7 @@ class BaseTrain:
     def save_model(
         self,
         trained_model_obj: "ModelObject",
-        tracker: UIRunProgressTracker,
+        tracker: RunProgressTracker,
     ) -> Any:
         pass
 

--- a/layer/training/runtime/model_trainer.py
+++ b/layer/training/runtime/model_trainer.py
@@ -191,21 +191,22 @@ class ModelTrainer:
                     self.train_context.model_name,
                 )
                 self.logger.info("Executed train_model_func successfully")
-                self._run_assertions(
-                    model,
-                    train_model_func.layer.get_assertions(),  # type: ignore
-                )
-                self.tracker.mark_model_saving(self.train_context.model_name)
-                self.logger.info(f"Saving model artifact {model} to model registry")
-                train.save_model(model, tracker=self.tracker)
+                if model:
+                    self._run_assertions(
+                        model,
+                        train_model_func.layer.get_assertions(),  # type: ignore
+                    )
+                    self.tracker.mark_model_saving(self.train_context.model_name)
+                    self.logger.info(f"Saving model artifact {model} to model registry")
+                    train.save_model(model, tracker=self.tracker)
+                    self.logger.info(
+                        f"Saved model artifact {model} to model registry successfully"
+                    )
                 update_train_status(
                     self.client.model_catalog,
                     self.train_context.train_id,
                     ModelTrainStatus.TRAIN_STATUS_SUCCESSFUL,
                     self.logger,
-                )
-                self.logger.info(
-                    f"Saved model artifact {model} to model registry successfully"
                 )
                 self.tracker.mark_model_saved(self.train_context.model_name)
                 return model

--- a/layer/training/train.py
+++ b/layer/training/train.py
@@ -10,7 +10,7 @@ from layer.clients.layer import LayerClient
 from layer.contracts.models import Model
 from layer.exceptions.exceptions import UnexpectedModelTypeException
 from layer.flavors.utils import get_flavor_for_model
-from layer.tracker.ui_progress_tracker import UIRunProgressTracker
+from layer.tracker.progress_tracker import RunProgressTracker
 from layer.types import ModelObject
 
 from ..contracts.project_full_name import ProjectFullName
@@ -71,7 +71,7 @@ class Train(BaseTrain):
     def save_model(
         self,
         model_object: ModelObject,
-        tracker: UIRunProgressTracker,
+        tracker: RunProgressTracker,
     ) -> Any:
         assert self.__train_id
 


### PR DESCRIPTION
Make models optional to return from the model decorator.

This should address https://github.com/layerai/sdk/issues/244 by letting users return `None` from their training runs without impacting Layer successfully finishing a training run and collecting metadata.