### PR TITLE
Add category parameter when logging data

### DIFF
--- a/layer/clients/logged_data_service.py
+++ b/layer/clients/logged_data_service.py
@@ -63,6 +63,7 @@ class LoggedDataClient:
         tag: str,
         points: List[ModelMetricPoint],
         metric_group_id: UUID,
+        category: Optional[str] = None,
     ) -> ModelMetricId:
         metric = LoggedModelMetric(
             unique_tag=tag,
@@ -71,6 +72,7 @@ class LoggedDataClient:
                 for p in points
             ],
             group_id=LoggedMetricGroupId(value=str(metric_group_id)),
+            category=category if category is not None else "",
         )
         request = LogModelMetricRequest(
             model_train_id=ModelTrainId(value=str(train_id)), metric=metric
@@ -86,6 +88,7 @@ class LoggedDataClient:
         train_id: Optional[UUID] = None,
         dataset_build_id: Optional[UUID] = None,
         epoch: Optional[int] = None,
+        category: Optional[str] = None,
     ) -> str:
         return self._log_data(
             tag,
@@ -93,6 +96,7 @@ class LoggedDataClient:
             train_id=train_id,
             dataset_build_id=dataset_build_id,
             epoch=epoch,
+            category=category,
         ).s3_path
 
     def log_text_data(
@@ -101,6 +105,7 @@ class LoggedDataClient:
         data: str,
         train_id: Optional[UUID] = None,
         dataset_build_id: Optional[UUID] = None,
+        category: Optional[str] = None,
     ) -> None:
         self._log_data(
             tag,
@@ -108,6 +113,7 @@ class LoggedDataClient:
             data=data,
             train_id=train_id,
             dataset_build_id=dataset_build_id,
+            category=category,
         )
 
     def log_markdown_data(
@@ -116,6 +122,7 @@ class LoggedDataClient:
         data: str,
         train_id: Optional[UUID] = None,
         dataset_build_id: Optional[UUID] = None,
+        category: Optional[str] = None,
     ) -> None:
         self._log_data(
             tag,
@@ -123,6 +130,7 @@ class LoggedDataClient:
             data=data,
             train_id=train_id,
             dataset_build_id=dataset_build_id,
+            category=category,
         )
 
     def log_numeric_data(
@@ -131,6 +139,7 @@ class LoggedDataClient:
         data: str,
         train_id: Optional[UUID] = None,
         dataset_build_id: Optional[UUID] = None,
+        category: Optional[str] = None,
     ) -> None:
         self._log_data(
             tag,
@@ -138,6 +147,7 @@ class LoggedDataClient:
             data=data,
             train_id=train_id,
             dataset_build_id=dataset_build_id,
+            category=category,
         )
 
     def log_boolean_data(
@@ -146,6 +156,7 @@ class LoggedDataClient:
         data: str,
         train_id: Optional[UUID] = None,
         dataset_build_id: Optional[UUID] = None,
+        category: Optional[str] = None,
     ) -> None:
         self._log_data(
             tag,
@@ -153,6 +164,7 @@ class LoggedDataClient:
             data=data,
             train_id=train_id,
             dataset_build_id=dataset_build_id,
+            category=category,
         )
 
     def log_table_data(
@@ -161,6 +173,7 @@ class LoggedDataClient:
         data: str,
         train_id: Optional[UUID] = None,
         dataset_build_id: Optional[UUID] = None,
+        category: Optional[str] = None,
     ) -> None:
         self._log_data(
             tag,
@@ -168,6 +181,7 @@ class LoggedDataClient:
             data=data,
             train_id=train_id,
             dataset_build_id=dataset_build_id,
+            category=category,
         )
 
     def _log_data(
@@ -178,6 +192,7 @@ class LoggedDataClient:
         train_id: Optional[UUID] = None,
         dataset_build_id: Optional[UUID] = None,
         epoch: Optional[int] = None,
+        category: Optional[str] = None,
     ) -> LogDataResponse:
         text = cast(str, data)
         request = LogDataRequest(
@@ -194,5 +209,6 @@ class LoggedDataClient:
             dataset_build_id=DatasetBuildId(value=str(dataset_build_id))
             if dataset_build_id is not None
             else None,
+            category=category if category is not None else "",
         )
         return self._service.LogData(request=request)

--- a/layer/main/log.py
+++ b/layer/main/log.py
@@ -47,10 +47,12 @@ def log(
         ],
     ],
     step: Optional[int] = None,
+    category: Optional[str] = None,
 ) -> None:
     """
     :param data: A dictionary in which each key is a string tag (i.e. name/id). The value can have different types. See examples below for more details.
     :param step: An optional non-negative integer that associates data with a particular step (epoch). This only takes effect if the logged data is to be associated with a model train (and *not* with a dataset build), and the data is either a number or an image.
+    :param category: An optional string that associates data with a particular category. This category is used for grouping in the web UI.
     :return: None
 
     Logs arbitrary data associated with a model train or a dataset build into Layer backend.
@@ -183,4 +185,4 @@ def log(
             dataset_build_id=dataset_build_id,
             logger=logger,
         )
-        log_data_runner.log(data=data, epoch=step)
+        log_data_runner.log(data=data, epoch=step, category=category)

--- a/test/unit/logged_data/test_log_data_runner.py
+++ b/test/unit/logged_data/test_log_data_runner.py
@@ -40,7 +40,7 @@ def test_given_runner_when_log_data_with_string_value_then_calls_log_text_data(
     string_value2 = "string-value"
 
     # when
-    runner.log({tag1: string_value1, tag2: string_value2})
+    runner.log({tag1: string_value1, tag2: string_value2}, category="category")
 
     # then
     logged_data_client.log_text_data.assert_any_call(
@@ -48,12 +48,14 @@ def test_given_runner_when_log_data_with_string_value_then_calls_log_text_data(
         tag=tag1,
         data=string_value1,
         dataset_build_id=dataset_build_id,
+        category="category",
     )
     logged_data_client.log_text_data.assert_any_call(
         train_id=train_id,
         tag=tag2,
         data=string_value2,
         dataset_build_id=dataset_build_id,
+        category="category",
     )
 
 
@@ -79,7 +81,7 @@ def test_given_runner_when_log_data_with_list_value_then_calls_log_text_data(
     value2 = ["x", 5.6, ["a", "b"]]
 
     # when
-    runner.log({tag1: value1, tag2: value2})
+    runner.log({tag1: value1, tag2: value2}, category="category")
 
     # then
     logged_data_client.log_text_data.assert_any_call(
@@ -87,12 +89,14 @@ def test_given_runner_when_log_data_with_list_value_then_calls_log_text_data(
         tag=tag1,
         data=str(value1),
         dataset_build_id=dataset_build_id,
+        category="category",
     )
     logged_data_client.log_text_data.assert_any_call(
         train_id=train_id,
         tag=tag2,
         data=str(value2),
         dataset_build_id=dataset_build_id,
+        category="category",
     )
 
 
@@ -118,7 +122,7 @@ def test_given_runner_when_log_data_with_numpy_array_value_then_calls_log_text_d
     value2 = np.array([[1, 2], [3, 4]])
 
     # when
-    runner.log({tag1: value1, tag2: value2})
+    runner.log({tag1: value1, tag2: value2}, category="category")
 
     # then
     logged_data_client.log_text_data.assert_any_call(
@@ -126,12 +130,14 @@ def test_given_runner_when_log_data_with_numpy_array_value_then_calls_log_text_d
         tag=tag1,
         data=str([1, 2]),
         dataset_build_id=dataset_build_id,
+        category="category",
     )
     logged_data_client.log_text_data.assert_any_call(
         train_id=train_id,
         tag=tag2,
         data=str([[1, 2], [3, 4]]),
         dataset_build_id=dataset_build_id,
+        category="category",
     )
 
 
@@ -155,7 +161,7 @@ def test_given_runner_when_log_data_with_bool_value_then_calls_log_boolean_data(
     boolean_value = False
 
     # when
-    runner.log({tag: boolean_value})
+    runner.log({tag: boolean_value}, category="category")
 
     # then
     logged_data_client.log_boolean_data.assert_called_with(
@@ -163,6 +169,7 @@ def test_given_runner_when_log_data_with_bool_value_then_calls_log_boolean_data(
         tag=tag,
         data=str(boolean_value),
         dataset_build_id=dataset_build_id,
+        category="category",
     )
 
 
@@ -180,7 +187,7 @@ def test_given_runner_when_log_numeric_value_without_epoch_then_calls_log_number
     numeric_value1 = 2.3
 
     # when
-    runner.log({tag1: numeric_value1})
+    runner.log({tag1: numeric_value1}, category="category")
 
     # then
     logged_data_client.log_numeric_data.assert_any_call(
@@ -188,6 +195,7 @@ def test_given_runner_when_log_numeric_value_without_epoch_then_calls_log_number
         tag=tag1,
         data=str(numeric_value1),
         dataset_build_id=None,
+        category="category",
     )
 
 
@@ -208,7 +216,9 @@ def test_given_runner_when_log_numeric_value_with_epoch_then_calls_log_metric() 
     epoch = 123
 
     # when
-    runner.log({tag1: numeric_value1, tag2: numeric_value2}, epoch=epoch)
+    runner.log(
+        {tag1: numeric_value1, tag2: numeric_value2}, epoch=epoch, category="category"
+    )
 
     # then
     logged_data_client.log_model_metric.assert_any_call(
@@ -216,6 +226,7 @@ def test_given_runner_when_log_numeric_value_with_epoch_then_calls_log_metric() 
         tag=tag1,
         points=[ModelMetricPoint(epoch=epoch, value=numeric_value1)],
         metric_group_id=ANY,
+        category="category",
     )
 
     logged_data_client.log_model_metric.assert_any_call(
@@ -223,6 +234,7 @@ def test_given_runner_when_log_numeric_value_with_epoch_then_calls_log_metric() 
         tag=tag2,
         points=[ModelMetricPoint(epoch=epoch, value=numeric_value2)],
         metric_group_id=ANY,
+        category="category",
     )
 
 
@@ -251,7 +263,7 @@ def test_given_runner_when_log_dict_then_calls_log_table(
     }
 
     # when
-    runner.log({tag: parameters})
+    runner.log({tag: parameters}, category="category")
 
     # then
     expected_dataframe = pd.DataFrame(
@@ -265,6 +277,7 @@ def test_given_runner_when_log_dict_then_calls_log_table(
         tag=tag,
         data=expected_dataframe_in_json,
         dataset_build_id=dataset_build_id,
+        category="category",
     )
 
 
@@ -314,7 +327,7 @@ def test_given_runner_when_log_pandas_dataframe_then_calls_log_table(
     )
     dataframe_in_json = dataframe.to_json(orient="table")
     # when
-    runner.log({tag: dataframe})
+    runner.log({tag: dataframe}, category="category")
 
     # then
     logged_data_client.log_table_data.assert_called_with(
@@ -322,6 +335,7 @@ def test_given_runner_when_log_pandas_dataframe_then_calls_log_table(
         tag=tag,
         data=dataframe_in_json,
         dataset_build_id=dataset_build_id,
+        category="category",
     )
 
 
@@ -381,7 +395,7 @@ def test_given_runner_when_log_ntchw_torch_tensor_video_then_calls_log_binary(
     assert video_object is not None
 
     # when
-    runner.log({tag: video})
+    runner.log({tag: video}, category="category")
 
     # then
     logged_data_client.log_binary_data.assert_called_with(
@@ -390,6 +404,7 @@ def test_given_runner_when_log_ntchw_torch_tensor_video_then_calls_log_binary(
         dataset_build_id=dataset_build_id,
         logged_data_type=LoggedDataType.LOGGED_DATA_TYPE_VIDEO,
         epoch=None,
+        category="category",
     )
     mock_put.assert_called_with("http://path/for/upload", data=ANY)
 
@@ -419,7 +434,7 @@ def test_given_runner_when_log_nparray_image_then_calls_log_binary(
     image = layer.Image(img, format="HWC")
 
     # when
-    runner.log({tag: image})
+    runner.log({tag: image}, category="category")
 
     # then
     logged_data_client.log_binary_data.assert_called_with(
@@ -428,6 +443,7 @@ def test_given_runner_when_log_nparray_image_then_calls_log_binary(
         dataset_build_id=dataset_build_id,
         logged_data_type=LoggedDataType.LOGGED_DATA_TYPE_IMAGE,
         epoch=None,
+        category="category",
     )
     mock_put.assert_called_with("http://path/for/upload", data=ANY)
 
@@ -463,7 +479,7 @@ def test_given_runner_when_log_hwc_torch_tensor_image_then_calls_log_binary(
     assert image_object.height == img_height
 
     # when
-    runner.log({tag: image})
+    runner.log({tag: image}, category="category")
 
     # then
     logged_data_client.log_binary_data.assert_called_with(
@@ -472,6 +488,7 @@ def test_given_runner_when_log_hwc_torch_tensor_image_then_calls_log_binary(
         dataset_build_id=dataset_build_id,
         logged_data_type=LoggedDataType.LOGGED_DATA_TYPE_IMAGE,
         epoch=None,
+        category="category",
     )
     mock_put.assert_called_with("http://path/for/upload", data=ANY)
 
@@ -502,7 +519,7 @@ def test_given_runner_when_log_hw_nparray_image_then_calls_log_binary(
     image = layer.Image(img, format="HW")
 
     # when
-    runner.log({tag: image})
+    runner.log({tag: image}, category="category")
 
     # then
     logged_data_client.log_binary_data.assert_called_with(
@@ -511,6 +528,7 @@ def test_given_runner_when_log_hw_nparray_image_then_calls_log_binary(
         dataset_build_id=dataset_build_id,
         logged_data_type=LoggedDataType.LOGGED_DATA_TYPE_IMAGE,
         epoch=None,
+        category="category",
     )
     mock_put.assert_called_with("http://path/for/upload", data=ANY)
 
@@ -543,7 +561,7 @@ def test_given_runner_when_log_hw_torch_tensor_image_then_calls_log_binary(
     image = layer.Image(tensor_image, format="HW")
 
     # when
-    runner.log({tag: image})
+    runner.log({tag: image}, category="category")
 
     # then
     logged_data_client.log_binary_data.assert_called_with(
@@ -552,6 +570,7 @@ def test_given_runner_when_log_hw_torch_tensor_image_then_calls_log_binary(
         dataset_build_id=dataset_build_id,
         logged_data_type=LoggedDataType.LOGGED_DATA_TYPE_IMAGE,
         epoch=None,
+        category="category",
     )
     mock_put.assert_called_with("http://path/for/upload", data=ANY)
 
@@ -578,7 +597,7 @@ def test_given_runner_when_log_image_then_calls_log_binary(
     image = PIL.Image.fromarray(image_data.astype("uint8")).convert("RGBA")
 
     # when
-    runner.log({tag: image})
+    runner.log({tag: image}, category="category")
 
     # then
     logged_data_client.log_binary_data.assert_called_with(
@@ -587,6 +606,7 @@ def test_given_runner_when_log_image_then_calls_log_binary(
         dataset_build_id=dataset_build_id,
         logged_data_type=LoggedDataType.LOGGED_DATA_TYPE_IMAGE,
         epoch=None,
+        category="category",
     )
     mock_put.assert_called_with("http://path/for/upload", data=ANY)
 
@@ -613,7 +633,7 @@ def test_given_runner_when_log_image_with_step_for_model_train_then_calls_log_bi
     image = PIL.Image.fromarray(image_data.astype("uint8")).convert("RGBA")
 
     # when
-    runner.log({tag: image}, epoch=123)
+    runner.log({tag: image}, epoch=123, category="category")
 
     # then
     logged_data_client.log_binary_data.assert_called_with(
@@ -622,6 +642,7 @@ def test_given_runner_when_log_image_with_step_for_model_train_then_calls_log_bi
         tag=tag,
         logged_data_type=LoggedDataType.LOGGED_DATA_TYPE_IMAGE,
         epoch=123,
+        category="category",
     )
     mock_put.assert_called_with("http://path/for/upload", data=ANY)
 
@@ -689,7 +710,7 @@ def test_given_runner_when_log_matplotlib_figure_then_calls_log_binary(
     ax.grid()
 
     # when
-    runner.log({tag: fig})
+    runner.log({tag: fig}, category="category")
 
     # then
     logged_data_client.log_binary_data.assert_called_with(
@@ -697,6 +718,7 @@ def test_given_runner_when_log_matplotlib_figure_then_calls_log_binary(
         tag=tag,
         dataset_build_id=dataset_build_id,
         logged_data_type=LoggedDataType.LOGGED_DATA_TYPE_IMAGE,
+        category="category",
     )
     mock_put.assert_called_with("http://path/for/upload", data=ANY)
 
@@ -748,7 +770,7 @@ def test_given_runner_when_log_matplotlib_module_then_calls_log_binary(
     ax.grid()
 
     # when
-    runner.log({tag: plt})
+    runner.log({tag: plt}, category="category")
 
     # then
     logged_data_client.log_binary_data.assert_called_with(
@@ -756,6 +778,7 @@ def test_given_runner_when_log_matplotlib_module_then_calls_log_binary(
         tag=tag,
         dataset_build_id=dataset_build_id,
         logged_data_type=LoggedDataType.LOGGED_DATA_TYPE_IMAGE,
+        category="category",
     )
     mock_put.assert_called_with("http://path/for/upload", data=ANY)
 
@@ -784,7 +807,7 @@ def test_given_runner_when_log_image_by_path_then_calls_log_binary(
     image.save(str(path))
 
     # when
-    runner.log({tag: Path(str(path))})
+    runner.log({tag: Path(str(path))}, category="category")
 
     # then
     logged_data_client.log_binary_data.assert_called_with(
@@ -793,6 +816,7 @@ def test_given_runner_when_log_image_by_path_then_calls_log_binary(
         dataset_build_id=dataset_build_id,
         logged_data_type=LoggedDataType.LOGGED_DATA_TYPE_IMAGE,
         epoch=None,
+        category="category",
     )
     mock_put.assert_called_with("http://path/for/upload", data=ANY)
 
@@ -819,7 +843,7 @@ def test_given_runner_when_log_video_by_path_then_calls_log_binary(
     Path(str(path)).touch()
 
     # when
-    runner.log({tag: Path(str(path))})
+    runner.log({tag: Path(str(path))}, category="category")
 
     # then
     logged_data_client.log_binary_data.assert_called_with(
@@ -828,6 +852,7 @@ def test_given_runner_when_log_video_by_path_then_calls_log_binary(
         dataset_build_id=dataset_build_id,
         logged_data_type=LoggedDataType.LOGGED_DATA_TYPE_VIDEO,
         epoch=None,
+        category="category",
     )
     mock_put.assert_called_with("http://path/for/upload", data=ANY)
 
@@ -880,7 +905,7 @@ def test_given_runner_when_log_markdown_then_calls_log_markdown(
     tag = "markdown-tag"
     md = layer.Markdown("# Foo bar")
     # when
-    runner.log({tag: md})
+    runner.log({tag: md}, category="category")
 
     # then
     logged_data_client.log_markdown_data.assert_called_with(
@@ -888,6 +913,7 @@ def test_given_runner_when_log_markdown_then_calls_log_markdown(
         tag=tag,
         data=md.data,
         dataset_build_id=dataset_build_id,
+        category="category",
     )
 
 


### PR DESCRIPTION
Extend `layer.log` with a `category` parameter, so it can be used like `layer.log({...}, category="test")`.
This will be used in the Web UI to group the logged data on it.