### PR TITLE
[LAY-3690] Report function metadata

### DIFF
--- a/layer/executables/entrypoint/common.py
+++ b/layer/executables/entrypoint/common.py
@@ -13,9 +13,10 @@ from layer.utils.async_utils import asyncio_run_in_thread
 ENV_LAYER_API_URL = "LAYER_API_URL"
 ENV_LAYER_API_KEY = "LAYER_API_KEY"
 ENV_LAYER_API_TOKEN = "LAYER_API_TOKEN"
+ENV_LAYER_RUN_ID = "LAYER_RUN_ID"
 
 RunnerFunction = Callable[[FunctionDefinition], Any]
-RunFunction = Callable[[FunctionDefinition, Config, Fabric], Any]
+RunFunction = Callable[[FunctionDefinition, Config, Fabric, str], Any]
 
 
 def make_runner(run_function: RunFunction) -> RunnerFunction:
@@ -23,7 +24,9 @@ def make_runner(run_function: RunFunction) -> RunnerFunction:
         def inner() -> Any:
             _initialize(definition)
             config: Config = asyncio_run_in_thread(ConfigManager().refresh())
-            return run_function(definition, config, _get_display_fabric())
+            return run_function(
+                definition, config, _get_display_fabric(), _get_run_id()
+            )
 
         return inner
 
@@ -47,3 +50,7 @@ def _initialize(definition: FunctionDefinition) -> None:
 
 def _get_display_fabric() -> Fabric:
     return Fabric.find(os.getenv("LAYER_FABRIC", "f-local"))
+
+
+def _get_run_id() -> str:
+    return os.getenv(ENV_LAYER_RUN_ID, "")

--- a/layer/executables/entrypoint/dataset.py
+++ b/layer/executables/entrypoint/dataset.py
@@ -38,7 +38,7 @@ set_has_shown_update_message(True)
 
 
 def _run(
-    dataset_definition: FunctionDefinition, config: Config, fabric: Fabric
+    dataset_definition: FunctionDefinition, config: Config, fabric: Fabric, run_id: str
 ) -> None:
 
     with LayerClient(config.client, logger).init() as client:
@@ -71,9 +71,8 @@ def _run(
                         dataset_definition.asset_name,
                         fabric.value,
                     )
-                    runId = RunId(value=str(uuid.uuid4()))  # TODO use runId from API
                     client.flow_manager.update_run_metadata(
-                        run_id=runId,
+                        run_id=RunId(value=run_id),
                         task_id=dataset_definition.asset_name,
                         task_type=Task.Type.TYPE_DATASET_BUILD,
                         key="build-id",

--- a/layer/executables/entrypoint/dataset.py
+++ b/layer/executables/entrypoint/dataset.py
@@ -71,13 +71,14 @@ def _run(
                         dataset_definition.asset_name,
                         fabric.value,
                     )
-                    client.flow_manager.update_run_metadata(
-                        run_id=RunId(value=run_id),
-                        task_id=dataset_definition.asset_name,
-                        task_type=Task.Type.TYPE_DATASET_BUILD,
-                        key="build-id",
-                        value=str(dataset_build_id),
-                    )
+                    if run_id:
+                        client.flow_manager.update_run_metadata(
+                            run_id=RunId(value=run_id),
+                            task_id=dataset_definition.asset_name,
+                            task_type=Task.Type.TYPE_DATASET_BUILD,
+                            key="build-id",
+                            value=str(dataset_build_id),
+                        )
                     context.with_dataset_build(
                         DatasetBuild(
                             id=dataset_build_id, status=DatasetBuildStatus.STARTED

--- a/layer/executables/entrypoint/dataset.py
+++ b/layer/executables/entrypoint/dataset.py
@@ -2,6 +2,9 @@ import logging
 import uuid
 from typing import Any, List
 
+from layerapi.api.entity.task_pb2 import Task
+from layerapi.api.ids_pb2 import RunId
+
 from layer.clients.layer import LayerClient
 from layer.config.config import Config
 from layer.context import Context
@@ -67,6 +70,14 @@ def _run(
                         current_project_uuid,
                         dataset_definition.asset_name,
                         fabric.value,
+                    )
+                    runId = RunId(value=str(uuid.uuid4()))  # TODO use runId from API
+                    client.flow_manager.update_run_metadata(
+                        run_id=runId,
+                        task_id=dataset_definition.asset_name,
+                        task_type=Task.Type.TYPE_DATASET_BUILD,
+                        key="build-id",
+                        value=str(dataset_build_id),
                     )
                     context.with_dataset_build(
                         DatasetBuild(

--- a/layer/executables/entrypoint/model.py
+++ b/layer/executables/entrypoint/model.py
@@ -47,14 +47,14 @@ def _run(
             train_id = client.model_catalog.create_model_train_from_version_id(
                 model_version.id
             )
-            client.flow_manager.update_run_metadata(
-                run_id=RunId(value=run_id),
-                task_id=model_definition.asset_name,
-                task_type=Task.Type.TYPE_DATASET_BUILD,
-                key="train-id",
-                value=str(train_id),
-            )
-
+            if run_id:
+                client.flow_manager.update_run_metadata(
+                    run_id=RunId(value=run_id),
+                    task_id=model_definition.asset_name,
+                    task_type=Task.Type.TYPE_DATASET_BUILD,
+                    key="train-id",
+                    value=str(train_id),
+                )
             train = client.model_catalog.get_model_train(train_id)
 
             context = LocalTrainContext(  # noqa: F841


### PR DESCRIPTION
Adds support for reporting runExecutionMetadata to the flow manager when the specific output of the function is known, either a `dataset_build_id` or a `model_train_id`