### PR TITLE
Add support for description for dataset and model decorators

### DIFF
--- a/layer/contracts/asset.py
+++ b/layer/contracts/asset.py
@@ -141,6 +141,7 @@ class BaseAsset(metaclass=ABCMeta):
         path: Union[str, AssetPath],
         id: Optional[uuid.UUID] = None,
         dependencies: Optional[Sequence["BaseAsset"]] = None,
+        description: Optional[str] = None,
     ):
         if dependencies is None:
             dependencies = []
@@ -149,6 +150,7 @@ class BaseAsset(metaclass=ABCMeta):
         )
         self._id = id
         self._dependencies = dependencies
+        self._description = description
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, BaseAsset):
@@ -174,6 +176,10 @@ class BaseAsset(metaclass=ABCMeta):
     @property
     def path(self) -> str:
         return self._path.path()
+
+    @property
+    def description(self) -> str:
+        return self._description or ""
 
     @property
     def id(self) -> uuid.UUID:

--- a/layer/contracts/datasets.py
+++ b/layer/contracts/datasets.py
@@ -62,9 +62,9 @@ class Dataset(BaseAsset):
             path=asset_path,
             id=id,
             dependencies=dependencies,
+            description=description,
         )
         self._version_id = version_id
-        self.description = description
         self.schema = schema
         self.metadata = metadata if metadata is not None else {}
         self.build = build or DatasetBuild()

--- a/layer/contracts/models.py
+++ b/layer/contracts/models.py
@@ -51,9 +51,9 @@ class Model(BaseAsset):
             path=asset_path,
             id=id,
             dependencies=dependencies,
+            description=description,
         )
         self._version_id = version_id
-        self._description = description
         self._flavor = flavor
         self._storage_config = storage_config
         self._model_runtime_objects = model_runtime_objects

--- a/layer/decorators/dataset_decorator.py
+++ b/layer/decorators/dataset_decorator.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 def dataset(
-    name: str, dependencies: Optional[List[Union[str, Dataset, Model]]] = None
+    name: str,
+    dependencies: Optional[List[Union[str, Dataset, Model]]] = None,
+    description: Optional[str] = None,
 ) -> Callable[..., Any]:
     """
     Decorator function that wraps a dataset function.
@@ -37,6 +39,7 @@ def dataset(
 
     :param name: Name with which the dataset will be stored in Layer backend.
     :param dependencies: List of ``Datasets`` or ``Models`` that will be built by Layer backend prior to building the current function. This hints Layer what entities this function depends on and optimizes the build process.
+    :param description: Optional description to be displayed in the UI.
     :return: Function object being decorated.
 
     .. code-block:: python
@@ -89,14 +92,14 @@ def dataset(
         from layer
         from layer.decorators import dataset
 
-        @dataset("raw_spam_dataset", dependencies=[layer.Dataset('layer/spam-detection/datasets/spam_messages')])
+        @dataset("raw_spam_dataset", dependencies=[layer.Dataset('layer/spam-detection/datasets/spam_messages')], description="Imporant dataset!")
         def raw_spam_dataset():
             # Get the spam_messages dataset and convert to Pandas dataframe.
             df = layer.get_dataset("spam-detection/datasets/spam_messages").to_pandas()
             return df
     """
 
-    @wrapt.decorator(proxy=_dataset_wrapper(name, dependencies))
+    @wrapt.decorator(proxy=_dataset_wrapper(name, dependencies, description))
     def wrapper(
         wrapped: Any, instance: Any, args: List[Any], kwargs: Dict[str, Any]
     ) -> None:
@@ -106,7 +109,9 @@ def dataset(
 
 
 def _dataset_wrapper(
-    name: str, dependencies: Optional[List[Union[str, Dataset, Model]]] = None
+    name: str,
+    dependencies: Optional[List[Union[str, Dataset, Model]]] = None,
+    description: Optional[str] = None,
 ) -> Any:
     class DatasetFunctionWrapper(LayerAssetFunctionWrapper):
         def __init__(self, wrapped: Any, wrapper: Any, enabled: Any) -> None:
@@ -117,6 +122,7 @@ def _dataset_wrapper(
                 AssetType.DATASET,
                 name,
                 dependencies,
+                description,
             )
 
     return DatasetFunctionWrapper

--- a/layer/decorators/layer_wrapper.py
+++ b/layer/decorators/layer_wrapper.py
@@ -48,10 +48,12 @@ class LayerAssetFunctionWrapper(LayerFunctionWrapper):
         asset_type: AssetType,
         name: str,
         dependencies: Optional[List[Union[str, Dataset, Model]]],
+        description: Optional[str],
     ) -> None:
         super().__init__(wrapped, wrapper, enabled)
         self.layer.set_asset_type(asset_type)
         self.layer.set_asset_name(name)
+        self.layer.set_description(description)
 
         paths: List[AssetPath] = []
         if dependencies is not None:
@@ -100,6 +102,7 @@ class LayerAssetFunctionWrapper(LayerFunctionWrapper):
             pip_dependencies=_get_pip_dependencies(self.layer),
             resource_paths=self.layer.get_resource_paths(),
             assertions=self.layer.get_assertions(),
+            description=self.layer.description,
         )
 
     def get_definition_with_bound_arguments(self) -> FunctionDefinition:

--- a/layer/decorators/model_decorator.py
+++ b/layer/decorators/model_decorator.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 def model(
-    name: str, dependencies: Optional[List[Union[str, Dataset, Model]]] = None
+    name: str,
+    dependencies: Optional[List[Union[str, Dataset, Model]]] = None,
+    description: Optional[str] = None,
 ) -> Callable[..., Any]:
     """
     Decorator function used to wrap another function that trains a model. The function that decorator has been applied to needs to return a ML model object from a supported framework.
@@ -23,6 +25,7 @@ def model(
 
     :param name: Name with which the model are stored in Layer's backend.
     :param dependencies: List of datasets or models that will be built by Layer backend prior to building the current function. Layer understand what entities this function depends on so it optimizes the build process accordingly.
+    :param description: Optional description to be displayed in the UI.
     :return: Function object being decorated.
 
     .. code-block:: python
@@ -55,7 +58,7 @@ def model(
         from layer
         from layer.decorators import dataset, model
 
-        @model(name='survival_model', dependencies=[layer.Dataset('layer/titanic/datasets/features')])
+        @model(name='survival_model', dependencies=[layer.Dataset('layer/titanic/datasets/features')], description="Some description")
         @assert_true(test_survival_probability)
         def train():
             df = layer.get_dataset("layer/titanic/datasets/features").to_pandas()
@@ -68,7 +71,7 @@ def model(
             return random_forest
     """
 
-    @wrapt.decorator(proxy=_model_wrapper(name, dependencies))
+    @wrapt.decorator(proxy=_model_wrapper(name, dependencies, description))
     def wrapper(
         wrapped: Any, instance: Any, args: List[Any], kwargs: Dict[str, Any]
     ) -> None:
@@ -80,6 +83,7 @@ def model(
 def _model_wrapper(
     name: str,
     dependencies: Optional[List[Union[str, Dataset, Model]]] = None,
+    description: Optional[str] = None,
 ) -> Any:
     class FunctionWrapper(LayerAssetFunctionWrapper):
         def __init__(self, wrapped: Any, wrapper: Any, enabled: Any) -> None:
@@ -90,6 +94,7 @@ def _model_wrapper(
                 AssetType.MODEL,
                 name,
                 dependencies,
+                description,
             )
 
     return FunctionWrapper

--- a/layer/settings.py
+++ b/layer/settings.py
@@ -23,6 +23,7 @@ def _resolve_settings(
 class LayerSettings:
     _asset_type: Optional[AssetType] = None
     _name: Optional[str] = None
+    _description: Optional[str] = None
     _fabric: Optional[Fabric] = None
     _pip_requirements_file: Optional[str] = None
     _pip_packages: Optional[List[str]] = None
@@ -51,6 +52,10 @@ class LayerSettings:
     @property
     def pip_requirements_file(self) -> str:
         return self.get_pip_requirements_file()
+
+    @property
+    def description(self) -> str:
+        return self._description or ""
 
     @property
     def conda_environment(self) -> Optional[CondaEnv]:
@@ -98,6 +103,9 @@ class LayerSettings:
 
     def set_asset_name(self, name: str) -> None:
         self._name = name
+
+    def set_description(self, description: Optional[str]) -> None:
+        self._description = description
 
     def set_fabric(self, f: str) -> None:
         if Fabric.has_member_key(f):

--- a/test/e2e/common_scenarios.py
+++ b/test/e2e/common_scenarios.py
@@ -44,7 +44,11 @@ def remote_run_with_dependent_datasets_succeeds_and_registers_metadata(
         )
         return pandas_df
 
-    @dataset(transformed_dataset_name, dependencies=[Dataset(dataset_name)])
+    @dataset(
+        transformed_dataset_name,
+        dependencies=[Dataset(dataset_name)],
+        description="some description",
+    )
     def transform_data():
         df = layer.get_dataset(dataset_name).to_pandas()
         df = df.drop(["address"], axis=1)
@@ -65,6 +69,7 @@ def remote_run_with_dependent_datasets_succeeds_and_registers_metadata(
     pandas = ds.to_pandas()
     assert len(pandas.index) == 10
     assert len(pandas.values[0]) == 4  # only 4 columns in modified dataset
+    assert ds.description == "some description"
 
 
 # project set from execution context
@@ -92,3 +97,4 @@ def remote_run_with_model_train_succeeds_and_registers_metadata(
     asserter.assert_run_succeeded(run.id)
     mdl = layer.get_model(model_name)
     assert isinstance(mdl.get_train(), SVC)
+    assert mdl.description == "some description"

--- a/test/e2e/common_scenarios.py
+++ b/test/e2e/common_scenarios.py
@@ -44,11 +44,7 @@ def remote_run_with_dependent_datasets_succeeds_and_registers_metadata(
         )
         return pandas_df
 
-    @dataset(
-        transformed_dataset_name,
-        dependencies=[Dataset(dataset_name)],
-        description="some description",
-    )
+    @dataset(transformed_dataset_name, dependencies=[Dataset(dataset_name)])
     def transform_data():
         df = layer.get_dataset(dataset_name).to_pandas()
         df = df.drop(["address"], axis=1)
@@ -69,7 +65,6 @@ def remote_run_with_dependent_datasets_succeeds_and_registers_metadata(
     pandas = ds.to_pandas()
     assert len(pandas.index) == 10
     assert len(pandas.values[0]) == 4  # only 4 columns in modified dataset
-    assert ds.description == "some description"
 
 
 # project set from execution context
@@ -97,4 +92,3 @@ def remote_run_with_model_train_succeeds_and_registers_metadata(
     asserter.assert_run_succeeded(run.id)
     mdl = layer.get_model(model_name)
     assert isinstance(mdl.get_train(), SVC)
-    assert mdl.description == "some description"

--- a/test/unit/decorators/test_dataset_decorator.py
+++ b/test/unit/decorators/test_dataset_decorator.py
@@ -25,7 +25,9 @@ from test.unit.decorators.util import project_client_mock
 
 def _make_test_dataset_function(name: str) -> Callable[..., Any]:
     @dataset(
-        name, dependencies=["datasets/bar", "models/foo", Dataset("baz"), Model("zoo")]
+        name,
+        dependencies=["datasets/bar", "models/foo", Dataset("baz"), Model("zoo")],
+        description="my description",
     )
     @pip_requirements(packages=["sklearn==0.0"])
     def func() -> pd.DataFrame:
@@ -105,6 +107,7 @@ class TestDatasetDecorator:
 
         assert dataset
         assert dataset.asset_name == name
+        assert dataset.description == "my description"
         assert dataset.project_name == test_project_name
         assert [
             (

--- a/test/unit/decorators/test_model_decorator.py
+++ b/test/unit/decorators/test_model_decorator.py
@@ -15,7 +15,9 @@ def _make_test_model_function(name: str) -> Callable[..., Any]:
     from sklearn.ensemble import RandomForestClassifier
 
     @model(
-        name, dependencies=["datasets/bar", "models/foo", Dataset("baz"), Model("zoo")]
+        name,
+        dependencies=["datasets/bar", "models/foo", Dataset("baz"), Model("zoo")],
+        description="my description",
     )
     @pip_requirements(packages=["scikit-learn==0.23.2"])
     def func() -> RandomForestClassifier:
@@ -53,6 +55,7 @@ class TestModelDecorator:
 
         assert model_definition.asset_name == name
         assert model_definition.project_name == "foo-test"
+        assert model_definition.description == "my description"
 
         assert len(model_definition.asset_dependencies) == 4
         assert model_definition.asset_dependencies[0].asset_name == "bar"


### PR DESCRIPTION
One can now set descriptions for datasets & models using decorators. Because `get_dataset` and `get_model` does not return the full objects (i.e. it lacks description), this PR does not yet update E2E tests. I'll create a task to track this bigger issue, then E2E testing this behavior will be trivial 1-2 line change.

I did update unit tests & manually tested it E2E:
<img width="527" alt="image" src="https://user-images.githubusercontent.com/461998/185893092-2f3f1931-1fc6-4608-97fc-77ac20d064f4.png">
