### PR TITLE
Log errors but do not stop executing on logging errors (part 1)

### DIFF
--- a/layer/context.py
+++ b/layer/context.py
@@ -5,6 +5,7 @@ from yarl import URL
 
 from layer.contracts.asset import AssetPath, AssetType
 from layer.contracts.datasets import DatasetBuild
+from layer.logged_data.logged_data_destination import LoggedDataDestination
 from layer.tracker.ui_progress_tracker import RunProgressTracker
 from layer.training.base_train import BaseTrain
 
@@ -45,6 +46,7 @@ class Context:
         self,
         url: URL,
         asset_path: AssetPath,
+        logged_data_destination: Optional[LoggedDataDestination] = None,
         tracker: Optional[RunProgressTracker] = None,
         train: Optional[BaseTrain] = None,
         dataset_build: Optional[DatasetBuild] = None,
@@ -63,6 +65,9 @@ class Context:
         self._asset_type = asset_path.asset_type
         self._train: Optional[BaseTrain] = train
         self._dataset_build: Optional[DatasetBuild] = dataset_build
+        self._logged_data_destination: Optional[
+            LoggedDataDestination
+        ] = logged_data_destination
         self._tracker: Optional[RunProgressTracker] = tracker
 
     def url(self) -> URL:
@@ -113,6 +118,9 @@ class Context:
 
     def asset_name(self) -> str:
         return self._asset_name
+
+    def logged_data_destination(self) -> Optional[LoggedDataDestination]:
+        return self._logged_data_destination
 
     def asset_type(self) -> AssetType:
         return self._asset_type

--- a/layer/contracts/tracker.py
+++ b/layer/contracts/tracker.py
@@ -192,6 +192,7 @@ class AssetTracker:
     status: AssetTrackerStatus = AssetTrackerStatus.PENDING
     base_url: Optional[URL] = None
     error_reason: str = ""
+    warnings: str = ""
     resource_transfer_state: Optional[ResourceTransferState] = None
     dataset_transfer_state: Optional[DatasetTransferState] = None
     model_transfer_state: Optional[ResourceTransferState] = None

--- a/layer/logged_data/data_logging_request.py
+++ b/layer/logged_data/data_logging_request.py
@@ -1,0 +1,26 @@
+from typing import Any, Callable, Optional
+
+from layerapi.api.service.logged_data.logged_data_api_pb2 import LogDataResponse
+
+from layer.logged_data.file_uploader import FileUploader
+
+
+class DataLoggingRequest:
+    def __init__(
+        self,
+        files_storage: FileUploader,
+        queued_operation_func: Callable[[], Optional[LogDataResponse]],
+        data: Optional[Any] = None,
+    ) -> None:
+        self._queued_operation_func = queued_operation_func
+        self._data = data
+        self._files_storage = files_storage
+
+    def execute(self) -> None:
+        data_logging_response = self._queued_operation_func()
+        if (
+            self._data is not None
+            and data_logging_response is not None
+            and data_logging_response.s3_path is not None
+        ):
+            self._files_storage.upload(data_logging_response.s3_path, self._data)

--- a/layer/logged_data/file_uploader.py
+++ b/layer/logged_data/file_uploader.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+import requests  # type: ignore
+
+
+class FileUploader:
+    def __init__(self) -> None:
+        retry_strategy = requests.packages.urllib3.util.retry.Retry(
+            total=5,
+            backoff_factor=1,
+            status_forcelist=[408, 429],  # timeout  # too many requests
+        )
+        adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
+
+        self._session = requests.Session()
+        self._session.mount("https://", adapter=adapter)
+
+    def upload(self, url: str, data: Any = None) -> None:
+        resp = self._session.put(url, data=data)
+        resp.raise_for_status()
+
+    def close(self) -> None:
+        self._session.close()

--- a/layer/logged_data/immediate_logged_data_destination.py
+++ b/layer/logged_data/immediate_logged_data_destination.py
@@ -1,0 +1,48 @@
+from types import TracebackType
+from typing import Any, Callable, Optional
+from uuid import UUID
+
+from layer.clients.logged_data_service import LoggedDataClient
+from layer.contracts.logged_data import LoggedData
+from layer.logged_data.data_logging_request import DataLoggingRequest
+from layer.logged_data.file_uploader import FileUploader
+from layer.logged_data.logged_data_destination import LoggedDataDestination
+
+
+class ImmediateLoggedDataDestination(LoggedDataDestination):
+    def get_logged_data(
+        self,
+        tag: str,
+        train_id: Optional[UUID] = None,
+        dataset_build_id: Optional[UUID] = None,
+    ) -> LoggedData:
+        return self._log_data_client.get_logged_data(
+            tag=tag, train_id=train_id, dataset_build_id=dataset_build_id
+        )
+
+    def __init__(self, client: LoggedDataClient) -> None:
+        self._log_data_client = client
+        self._files_storage = FileUploader()
+
+    def __enter__(self) -> LoggedDataDestination:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[BaseException],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self._files_storage.close()
+
+    def receive(
+        self,
+        func: Callable[[LoggedDataClient], Optional[Any]],
+        data: Optional[Any] = None,
+    ) -> None:
+        DataLoggingRequest(
+            self._files_storage, lambda: func(self._log_data_client), data
+        ).execute()
+
+    def get_logging_errors(self) -> None:
+        pass

--- a/layer/logged_data/logged_data_destination.py
+++ b/layer/logged_data/logged_data_destination.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Optional
+from uuid import UUID
+
+from layer.clients.logged_data_service import LoggedDataClient
+from layer.contracts.logged_data import LoggedData
+
+
+class LoggedDataDestination(ABC):
+    @abstractmethod
+    def get_logged_data(
+        self,
+        tag: str,
+        train_id: Optional[UUID] = None,
+        dataset_build_id: Optional[UUID] = None,
+    ) -> LoggedData:
+        pass
+
+    @abstractmethod
+    def receive(
+        self,
+        func: Callable[[LoggedDataClient], Optional[Any]],
+        data: Optional[Any] = None,
+    ) -> None:
+        pass
+
+    @abstractmethod
+    def get_logging_errors(self) -> Optional[str]:
+        pass

--- a/layer/logged_data/queuing_logged_data_destination.py
+++ b/layer/logged_data/queuing_logged_data_destination.py
@@ -1,0 +1,111 @@
+import queue
+import threading
+from queue import Queue
+from types import TracebackType
+from typing import Any, Callable, Optional
+from uuid import UUID
+
+from layer.clients.logged_data_service import LoggedDataClient
+from layer.contracts.logged_data import LoggedData
+from layer.logged_data.data_logging_request import DataLoggingRequest
+from layer.logged_data.file_uploader import FileUploader
+from layer.logged_data.logged_data_destination import LoggedDataDestination
+
+
+WAIT_INTERVAL_SECONDS = 1
+LOGGING_TIMEOUT = 30
+
+
+class QueueingLoggedDataDestination(LoggedDataDestination):
+    def __init__(self, client: LoggedDataClient) -> None:
+        self._logged_data_client = client
+        self._files_storage = FileUploader()
+
+        self._sending_errors: str = ""
+        self._stop_reading = False
+        self._local_queue: Queue[DataLoggingRequest] = Queue()
+        self._reading_thread = threading.Thread(target=self._execute_elem_from_queue)
+
+    def __enter__(self) -> "QueueingLoggedDataDestination":
+        self._reading_thread.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[BaseException],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self._exit()
+
+    def get_logged_data(
+        self,
+        tag: str,
+        train_id: Optional[UUID] = None,
+        dataset_build_id: Optional[UUID] = None,
+    ) -> LoggedData:
+        return self._logged_data_client.get_logged_data(
+            tag=tag, train_id=train_id, dataset_build_id=dataset_build_id
+        )
+
+    def receive(
+        self,
+        func: Callable[[LoggedDataClient], Optional[Any]],
+        data: Optional[Any] = None,
+    ) -> None:
+        self._local_queue.put_nowait(
+            DataLoggingRequest(
+                files_storage=self._files_storage,
+                queued_operation_func=lambda: func(self._logged_data_client),
+                data=data,
+            )
+        )
+
+    def get_logging_errors(self) -> Optional[str]:
+        self._exit()
+        return (
+            None
+            if len(self._sending_errors) == 0
+            else f"WARNING: Layer was unable to log requested data because of the following errors:\n{self._sending_errors}"
+        )
+
+    def _exit(self) -> None:
+        if not self._stop_reading:
+            self._stop_reading = True
+            self._reading_thread.join(timeout=LOGGING_TIMEOUT)
+            if self._reading_thread.is_alive():
+                # this means that there is some active logging request that is being executed for more than
+                # LOGGING_TIMEOUT
+                self._sending_errors = (
+                    self._sending_errors + f"Requested data could not be logged within "
+                    f"{LOGGING_TIMEOUT}s after finished execution,"
+                    f" giving up.\n"
+                )
+            else:  # in the case the thread was stopped, but there is still something unprocessed in the qeueue
+                self._flush_queue()
+            self._files_storage.close()
+
+    def _execute_elem_from_queue(self) -> None:
+        while not self._stop_reading:
+            try:
+                execution_item = self._local_queue.get(
+                    block=True, timeout=WAIT_INTERVAL_SECONDS
+                )
+                execution_item.execute()
+            except queue.Empty:
+                # no item in the queue, wait for another
+                pass
+            except Exception as ex:
+                self._append_to_error_message(ex)
+
+    def _flush_queue(self) -> None:
+        while not self._local_queue.empty():
+            execution_item = self._local_queue.get(block=False)
+            try:
+                execution_item.execute()
+            except Exception as ex:
+                self._append_to_error_message(ex)
+        return
+
+    def _append_to_error_message(self, ex: Exception) -> None:
+        self._sending_errors = self._sending_errors + f"Exception: {ex}\n"

--- a/layer/logged_data/read_only_logged_data_destination.py
+++ b/layer/logged_data/read_only_logged_data_destination.py
@@ -1,0 +1,31 @@
+from typing import Any, Callable, Optional
+from uuid import UUID
+
+from layer.clients.logged_data_service import LoggedDataClient
+from layer.contracts.logged_data import LoggedData
+from layer.logged_data.logged_data_destination import LoggedDataDestination
+
+
+class ReadOnlyLoggedDataDestination(LoggedDataDestination):
+    def __init__(self, client: LoggedDataClient) -> None:
+        self._log_data_client = client
+
+    def get_logged_data(
+        self,
+        tag: str,
+        train_id: Optional[UUID] = None,
+        dataset_build_id: Optional[UUID] = None,
+    ) -> LoggedData:
+        return self._log_data_client.get_logged_data(
+            tag=tag, train_id=train_id, dataset_build_id=dataset_build_id
+        )
+
+    def receive(
+        self,
+        func: Callable[[LoggedDataClient], Optional[Any]],
+        data: Optional[Any] = None,
+    ) -> None:
+        raise RuntimeError("Readonly logged data destination can only be read.")
+
+    def get_logging_errors(self) -> None:
+        raise RuntimeError("Readonly logged data destination can only be read.")

--- a/layer/tracker/asset_column.py
+++ b/layer/tracker/asset_column.py
@@ -73,6 +73,13 @@ class AssetColumn(ProgressColumn):
             table.add_column()
             table.add_row(self._render_url(asset))
             renderables.append(table)
+        if asset.warnings:
+            table = Table.grid(padding=(0, 1, 0, 1), pad_edge=True)
+            table.add_column(overflow="fold")
+            table.add_row(
+                Text.from_markup(f"[orange]{escape(asset.warnings)}[/orange]")
+            )
+            renderables.append(table)
         if asset.error_reason:
             table = Table.grid(padding=(0, 1, 0, 1), pad_edge=True)
             table.add_column(overflow="fold")

--- a/layer/tracker/non_ui_progress_tracker.py
+++ b/layer/tracker/non_ui_progress_tracker.py
@@ -43,6 +43,7 @@ class NonUIRunProgressTracker(RunProgressTracker):
         self,
         name: str,
         *,
+        warnings: Optional[str] = None,
         version: Optional[str] = None,
         build_index: Optional[str] = None,
     ) -> None:
@@ -54,6 +55,7 @@ class NonUIRunProgressTracker(RunProgressTracker):
     def mark_model_saved(
         self,
         name: str,
+        warnings: Optional[str] = None,
         version: Optional[str] = None,
         train_index: Optional[str] = None,
     ) -> None:

--- a/layer/tracker/progress_tracker.py
+++ b/layer/tracker/progress_tracker.py
@@ -50,6 +50,7 @@ class RunProgressTracker(ABC):
         self,
         name: str,
         *,
+        warnings: Optional[str] = None,
         version: Optional[str] = None,
         build_index: Optional[str] = None,
     ) -> None:
@@ -63,6 +64,7 @@ class RunProgressTracker(ABC):
     def mark_model_saved(
         self,
         name: str,
+        warnings: Optional[str] = None,
         version: Optional[str] = None,
         train_index: Optional[str] = None,
     ) -> None:

--- a/layer/tracker/ui_progress_tracker.py
+++ b/layer/tracker/ui_progress_tracker.py
@@ -113,6 +113,7 @@ class UIRunProgressTracker(RunProgressTracker):
         version: Optional[str] = None,
         build_idx: Optional[str] = None,
         error_reason: str = "",
+        warnings: Optional[str] = None,
         description: Optional[str] = None,
         model_transfer_state: Optional[ResourceTransferState] = None,
         dataset_transfer_state: Optional[DatasetTransferState] = None,
@@ -134,6 +135,8 @@ class UIRunProgressTracker(RunProgressTracker):
             asset.build_idx = build_idx
         if error_reason:
             asset.error_reason = error_reason
+        if warnings:
+            asset.warnings = warnings
         if dataset_transfer_state:
             asset.dataset_transfer_state = dataset_transfer_state
         if model_transfer_state:
@@ -247,6 +250,7 @@ class UIRunProgressTracker(RunProgressTracker):
         self,
         name: str,
         *,
+        warnings: Optional[str] = None,
         version: Optional[str] = None,
         build_index: Optional[str] = None,
     ) -> None:
@@ -257,6 +261,7 @@ class UIRunProgressTracker(RunProgressTracker):
             url=self._get_url(AssetType.DATASET, name),
             version=version,
             build_idx=build_index,
+            warnings=warnings,
         )
 
     def mark_model_saving(self, name: str) -> None:
@@ -269,6 +274,7 @@ class UIRunProgressTracker(RunProgressTracker):
     def mark_model_saved(
         self,
         name: str,
+        warnings: Optional[str] = None,
         version: Optional[str] = None,
         train_index: Optional[str] = None,
     ) -> None:
@@ -279,6 +285,7 @@ class UIRunProgressTracker(RunProgressTracker):
             url=self._get_url(AssetType.MODEL, name),
             version=version,
             build_idx=train_index,
+            warnings=warnings,
         )
 
     def mark_model_training(

--- a/test/unit/logged_data/test_log_data_runner.py
+++ b/test/unit/logged_data/test_log_data_runner.py
@@ -16,6 +16,9 @@ from requests import Session  # type: ignore
 import layer
 from layer.clients.logged_data_service import LoggedDataClient
 from layer.contracts.logged_data import XCoordinateType
+from layer.logged_data.immediate_logged_data_destination import (
+    ImmediateLoggedDataDestination,
+)
 from layer.logged_data.log_data_runner import LogDataRunner
 
 
@@ -441,7 +444,7 @@ def test_log_data(
     )
 
     runner = LogDataRunner(
-        client=logged_data_client,
+        logged_data_destination=ImmediateLoggedDataDestination(logged_data_client),
         dataset_build_id=dataset_build_id,
         train_id=train_id,
         logger=None,
@@ -593,17 +596,17 @@ def test_log_data_raises_error(
     expected_error: Any,
     expected_error_pattern: str,
 ) -> None:
-    logged_data_client = MagicMock(spec=LoggedDataClient)
+    logged_data_client = MagicMock()
     logged_data_client.log_data.return_value = MagicMock(
         spec=LogDataResponse,
         s3_path="http://path/for/upload",
     )
 
     runner = LogDataRunner(
-        client=logged_data_client,
         dataset_build_id=dataset_build_id,
         train_id=train_id,
         logger=None,
+        logged_data_destination=ImmediateLoggedDataDestination(logged_data_client),
     )
 
     # given

--- a/test/unit/logged_data/test_queuing_logged_data_destination.py
+++ b/test/unit/logged_data/test_queuing_logged_data_destination.py
@@ -1,0 +1,56 @@
+from typing import Any, Optional
+from unittest.mock import MagicMock, patch
+
+from layerapi.api.service.logged_data.logged_data_api_pb2 import LogDataResponse
+
+from layer.clients.logged_data_service import LoggedDataClient
+from layer.logged_data.queuing_logged_data_destination import (
+    QueueingLoggedDataDestination,
+)
+
+
+def test_given_errors_on_upload_and_grpc_when_get_errors_then_returns_all_errors() -> None:
+    # given
+    error_message = "Something happened!"
+    other_error_message = "Something else happened!"
+
+    def queued_failed_execution(__: LoggedDataClient):
+        raise Exception(error_message)
+
+    def queued_successful_execution(__: LoggedDataClient):
+        response = LogDataResponse()
+        response.s3_path = "https://valid_url"
+        return response
+
+    def failed_upload(_: str, __: Optional[Any] = None):
+        raise Exception(other_error_message)
+
+    logged_data_client = MagicMock()
+
+    with patch(
+        "layer.logged_data.file_uploader.FileUploader.upload", side_effect=failed_upload
+    ), QueueingLoggedDataDestination(logged_data_client) as destination:
+
+        destination.receive(queued_failed_execution)
+        destination.receive(queued_successful_execution, data="12345")
+
+        # when
+        errors = destination.get_logging_errors()
+
+        # then
+        assert (
+            errors
+            == f"WARNING: Layer was unable to log requested data because of the following errors:\nException: {error_message}\nException: {other_error_message}\n"
+        )
+
+
+def test_given_logging_successful_then_no_errors() -> None:
+    logged_data_client = MagicMock()
+
+    def queued_ok_execution(__: LoggedDataClient):
+        pass
+
+    with QueueingLoggedDataDestination(logged_data_client) as destination:
+        destination.receive(queued_ok_execution)
+        assert destination.get_logging_errors() is None
+        assert destination.get_logging_errors() is None


### PR DESCRIPTION
**Eventual Objective**: Log data in the background and do not interrupt execution if there is an error logging data. Attach error information (as a warning) to progress tracker's output in local mode.

**What this part doesn't do**: 
In this PR we're not changing any behaviour except for the added `close` call to http session when uploading files; new destination is not initialised in context yet and log function is falling back either to `ImmediateLoggedDataDestination` (which mimics current behaviour) or `ReadOnlyLoggedDataDestination` (which mimics current behaviour for the read part) based on execution context.
This PR just prepares classes so that they can be used by executables in next step, once new version of sdk is published.

**What this part does**: 
1) Introduce a concept of `LoggedDataDestination` with multiple implementations. One of them is the new implementation `QueuingLoggedDataDestination` which has new behaviour of adding logging requests to a queue, ignoring errors (if any) and just adding them to a list of error message that can be retrieved from the instance upon close.  `ImmediateLoggedDataDestination` mimics current logging behaviour with the exception that we call close on http session in `__exit__` which is not the case currently.
2) Prepare tracker to print warnings in local mode.


**Important trade-offs:**
* no support for tracker in remote mode yet, but for remote runs, the error message would be included in execution logs with the local tracker:
<img width="968" alt="image" src="https://user-images.githubusercontent.com/15348256/186877285-fe5a6250-f463-473f-8be2-d631b70e886d.png">



* in new queueing implementation, logging errors are not logged with python `logger` because it breaks the tracker experience in local mode. Since errors are printed below the tracker, they are be included in execution logs anyway, so I decided that additional logging would bring no benefit. 
* in new queueing implementation, when execution finishes, we wait for the reading thread for up to TIMEOUT s (currently 30s). that means that if execution is finished, and there is a single item that's still uploading for that long, we will close its http connection and give up. Other valid choice would be not to have timeout and let all uploading/retries finish no matter how long they take.


