### PR TITLE
Only keep read methods in Context

### DIFF
--- a/layer/context.py
+++ b/layer/context.py
@@ -7,9 +7,34 @@ from layer.tracker.ui_progress_tracker import RunProgressTracker
 from layer.training.base_train import BaseTrain
 
 
+# We store the active context temporarily so it can be used within
+# either a @layer decorated function or soon via `with layer.model() as context:`
+_ACTIVE_CONTEXT: Optional["Context"] = None
+
+
+def set_active_context(context: "Context") -> None:
+    global _ACTIVE_CONTEXT
+    _ACTIVE_CONTEXT = context
+
+
+def reset_active_context() -> None:
+    global _ACTIVE_CONTEXT
+    _ACTIVE_CONTEXT = None
+
+
+def get_active_context() -> Optional["Context"]:
+    """
+    Returns the active context object set from the active computation.
+    Used in local mode to identify which context to log resources to.
+
+    @return:  active context object
+    """
+    return _ACTIVE_CONTEXT
+
+
 class Context:
     """
-    Provides access to variables within the pipeline execution.
+    Provides access to variables within a given execution, for example during a model train.
 
     This class should not be initialized by end-users.
     """

--- a/layer/context.py
+++ b/layer/context.py
@@ -16,11 +16,11 @@ class Context:
 
     def __init__(
         self,
+        asset_name: str,
+        asset_type: AssetType,
+        tracker: Optional[RunProgressTracker] = None,
         train: Optional[BaseTrain] = None,
         dataset_build: Optional[DatasetBuild] = None,
-        tracker: Optional[RunProgressTracker] = None,
-        asset_name: Optional[str] = None,
-        asset_type: Optional[AssetType] = None,
     ) -> None:
         self._train: Optional[BaseTrain] = train
         self._dataset_build: Optional[DatasetBuild] = dataset_build

--- a/layer/context.py
+++ b/layer/context.py
@@ -45,24 +45,9 @@ class Context:
         """
         Retrieves the active Layer dataset build object.
 
-        :return: Represents the current dataset build of the dataset, passed by Layer when building of the dataset starts.
+        :return: Represents the current build of the dataset, passed by Layer when building of the dataset starts.
         """
         return self._dataset_build
-
-    def with_train(self, train: Optional[BaseTrain]) -> None:
-        self._train = train
-
-    def with_dataset_build(self, dataset_build: Optional[DatasetBuild]) -> None:
-        self._dataset_build = dataset_build
-
-    def with_tracker(self, tracker: RunProgressTracker) -> None:
-        self._tracker = tracker
-
-    def with_asset_name(self, asset_name: str) -> None:
-        self._asset_name = asset_name
-
-    def with_asset_type(self, asset_type: AssetType) -> None:
-        self._asset_type = asset_type
 
     def tracker(self) -> Optional[RunProgressTracker]:
         return self._tracker

--- a/layer/executables/entrypoint/dataset.py
+++ b/layer/executables/entrypoint/dataset.py
@@ -7,7 +7,7 @@ from layerapi.api.ids_pb2 import RunId
 
 from layer.clients.layer import LayerClient
 from layer.config.config import Config
-from layer.context import Context
+from layer.context import Context, reset_active_context, set_active_context
 from layer.contracts.assertions import Assertion
 from layer.contracts.assets import AssetType
 from layer.contracts.datasets import DatasetBuild, DatasetBuildStatus
@@ -20,11 +20,7 @@ from layer.exceptions.exceptions import (
     LayerServiceUnavailableExceptionDuringInitialization,
     ProjectInitializationException,
 )
-from layer.global_context import (
-    reset_active_context,
-    set_active_context,
-    set_has_shown_update_message,
-)
+from layer.global_context import set_has_shown_update_message
 from layer.projects.utils import verify_project_exists_and_retrieve_project_id
 from layer.tracker.progress_tracker import RunProgressTracker
 from layer.tracker.utils import get_progress_tracker

--- a/layer/executables/entrypoint/model_trainer.py
+++ b/layer/executables/entrypoint/model_trainer.py
@@ -13,6 +13,7 @@ from layerapi.api.ids_pb2 import ModelTrainId
 from layer import Context
 from layer.clients.layer import LayerClient
 from layer.contracts.assertions import Assertion
+from layer.contracts.asset import AssetType
 from layer.exceptions.exception_handler import exception_handler
 from layer.exceptions.exceptions import LayerFailedAssertionsException
 from layer.exceptions.status_report import (
@@ -143,18 +144,20 @@ class ModelTrainer:
         project_full_name = current_project_full_name()
         if not project_full_name:
             raise Exception("Internal Error: missing current project full name")
-        with Context() as context:
-            with Train(
-                layer_client=self.client,
-                name=self.train_context.model_name,
-                project_full_name=project_full_name,
-                version=self.train_context.model_version,
-                train_id=self.train_context.train_id,
-                train_index=self.train_context.train_index,
-            ) as train:
-                context.with_train(train)
-                context.with_tracker(self.tracker)
-                context.with_asset_name(self.train_context.model_name)
+        with Train(
+            layer_client=self.client,
+            name=self.train_context.model_name,
+            project_full_name=project_full_name,
+            version=self.train_context.model_version,
+            train_id=self.train_context.train_id,
+            train_index=self.train_context.train_index,
+        ) as train:
+            with Context(
+                train=train,
+                tracker=self.tracker,
+                asset_name=self.train_context.model_name,
+                asset_type=AssetType.MODEL,
+            ) as context:
                 self.train_context.init_or_save_context(context)
                 self._update_train_status(
                     self.train_context.train_id,

--- a/layer/executables/entrypoint/model_trainer.py
+++ b/layer/executables/entrypoint/model_trainer.py
@@ -12,6 +12,7 @@ from layerapi.api.ids_pb2 import ModelTrainId
 
 from layer import Context
 from layer.clients.layer import LayerClient
+from layer.context import reset_active_context, set_active_context
 from layer.contracts.assertions import Assertion
 from layer.contracts.asset import AssetType
 from layer.exceptions.exception_handler import exception_handler
@@ -21,11 +22,7 @@ from layer.exceptions.status_report import (
     ExecutionStatusReportFactory,
     PythonExecutionStatusReport,
 )
-from layer.global_context import (
-    current_project_full_name,
-    reset_active_context,
-    set_active_context,
-)
+from layer.global_context import current_project_full_name
 from layer.resource_manager import ResourceManager
 from layer.tracker.progress_tracker import RunProgressTracker
 from layer.training.train import Train

--- a/layer/global_context.py
+++ b/layer/global_context.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
-from .context import Context
 from .contracts.fabrics import Fabric
 from .contracts.project_full_name import ProjectFullName
 
@@ -10,7 +9,6 @@ from .contracts.project_full_name import ProjectFullName
 class GlobalContext:
     project_full_name: Optional[ProjectFullName]
     fabric: Optional[Fabric]
-    active_context: Optional[Context]
     pip_requirements_file: Optional[str]
     pip_packages: Optional[List[str]]
     # We show a message to the user if their installed layer version is outdated.
@@ -20,12 +18,11 @@ class GlobalContext:
     has_shown_python_version_message: bool
 
 
-# We store project name, fabric, active context and requirements
+# We store full project name, fabric and requirements
 # at the process level for use in subsequent calls in the same Python process.
 _GLOBAL_CONTEXT = GlobalContext(
     project_full_name=None,
     fabric=None,
-    active_context=None,
     pip_requirements_file=None,
     pip_packages=None,
     has_shown_update_message=False,
@@ -40,7 +37,6 @@ def reset_to(project_full_name: Optional[Union[str, ProjectFullName]]) -> None:
         _GLOBAL_CONTEXT = GlobalContext(
             project_full_name=project_full_name,
             fabric=None,
-            active_context=None,
             pip_requirements_file=None,
             pip_packages=None,
             has_shown_update_message=False,
@@ -83,24 +79,6 @@ def current_account_name() -> Optional[str]:
         if _GLOBAL_CONTEXT.project_full_name
         else None
     )
-
-
-def set_active_context(context: Context) -> None:
-    _GLOBAL_CONTEXT.active_context = context
-
-
-def reset_active_context() -> None:
-    _GLOBAL_CONTEXT.active_context = None
-
-
-def get_active_context() -> Optional[Context]:
-    """
-    Returns the active context object set from the active computation. Used in local mode to identify which
-    context to log resources to.
-
-    @return:  active context object
-    """
-    return _GLOBAL_CONTEXT.active_context
 
 
 def set_default_fabric(fabric: Fabric) -> None:

--- a/layer/logged_data/loggers/pytorch_lightning.py
+++ b/layer/logged_data/loggers/pytorch_lightning.py
@@ -214,7 +214,7 @@ class PytorchLightningLogger(Logger):
 
     @property
     def _context(self) -> Any:
-        return layer.global_context.get_active_context()
+        return layer.context.get_active_context()
 
     def log_text(self, key: str, text: str) -> None:
         """Log text.

--- a/layer/main/asset.py
+++ b/layer/main/asset.py
@@ -72,16 +72,17 @@ def get_dataset(name: str, no_cache: bool = False) -> Dataset:
             )
             if not within_run:
                 try:
-                    with Context() as context:
+                    tracker = get_progress_tracker(
+                        url=config.url,
+                        account_name=asset_path.must_org_name(),
+                        project_name=asset_path.must_project_name(),
+                    )
+                    with Context(
+                        asset_type=AssetType.DATASET,
+                        asset_name=asset_path.asset_name,
+                        tracker=tracker,
+                    ) as context:
                         set_active_context(context)
-                        context.with_asset_name(asset_path.asset_name)
-                        context.with_asset_type(AssetType.DATASET)
-                        tracker = get_progress_tracker(
-                            url=config.url,
-                            account_name=asset_path.must_org_name(),
-                            project_name=asset_path.must_project_name(),
-                        )
-                        context.with_tracker(tracker)
                         with tracker.track():
                             dataset = _ui_progress_with_tracker(
                                 callback,
@@ -157,16 +158,17 @@ def get_model(name: str, no_cache: bool = False) -> Model:
 
         if not within_run:
             try:
-                with Context() as context:
+                tracker = get_progress_tracker(
+                    url=config.url,
+                    account_name=asset_path.must_org_name(),
+                    project_name=asset_path.must_project_name(),
+                )
+                with Context(
+                    asset_type=AssetType.MODEL,
+                    asset_name=asset_path.asset_name,
+                    tracker=tracker,
+                ) as context:
                     set_active_context(context)
-                    context.with_asset_name(asset_path.asset_name)
-                    context.with_asset_type(AssetType.MODEL)
-                    tracker = get_progress_tracker(
-                        url=config.url,
-                        account_name=asset_path.must_org_name(),
-                        project_name=asset_path.must_project_name(),
-                    )
-                    context.with_tracker(tracker)
                     with tracker.track():
                         model = _ui_progress_with_tracker(
                             callback,

--- a/layer/main/asset.py
+++ b/layer/main/asset.py
@@ -5,19 +5,19 @@ from layer.cache.utils import is_cached
 from layer.clients.layer import LayerClient
 from layer.config import ConfigManager
 from layer.config.config import Config
-from layer.context import Context
+from layer.context import (
+    Context,
+    get_active_context,
+    reset_active_context,
+    set_active_context,
+)
 from layer.contracts.assets import AssetPath, AssetType
 from layer.contracts.datasets import Dataset
 from layer.contracts.models import Model
 from layer.contracts.project_full_name import ProjectFullName
 from layer.contracts.tracker import ResourceTransferState
 from layer.exceptions.exceptions import ProjectInitializationException
-from layer.global_context import (
-    current_account_name,
-    get_active_context,
-    reset_active_context,
-    set_active_context,
-)
+from layer.global_context import current_account_name
 from layer.projects.utils import get_current_project_full_name
 from layer.tracker.utils import get_progress_tracker
 from layer.utils.async_utils import asyncio_run_in_thread

--- a/layer/main/log.py
+++ b/layer/main/log.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from layer.clients.layer import LayerClient
 from layer.config import ConfigManager
+from layer.context import get_active_context
 from layer.contracts.logged_data import Image, Markdown
-from layer.global_context import get_active_context
 from layer.logged_data.log_data_runner import LogDataRunner
 from layer.utils.async_utils import asyncio_run_in_thread
 

--- a/layer/training/runtime/model_trainer.py
+++ b/layer/training/runtime/model_trainer.py
@@ -11,14 +11,11 @@ from layerapi.api.entity.model_train_status_pb2 import ModelTrainStatus
 
 from layer import Context
 from layer.clients.layer import LayerClient
+from layer.context import reset_active_context, set_active_context
 from layer.contracts.assertions import Assertion
 from layer.exceptions.exception_handler import exception_handler
 from layer.exceptions.exceptions import LayerFailedAssertionsException
-from layer.global_context import (
-    current_project_full_name,
-    reset_active_context,
-    set_active_context,
-)
+from layer.global_context import current_project_full_name
 from layer.resource_manager import ResourceManager
 from layer.tracker.progress_tracker import RunProgressTracker
 from layer.training.train import Train

--- a/test/e2e/test_function_dataset_run.py
+++ b/test/e2e/test_function_dataset_run.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 
 import layer
-from layer import global_context
+from layer import context, global_context
 from layer.clients.layer import LayerClient
 from layer.contracts.fabrics import Fabric
 from layer.contracts.projects import Project
@@ -48,7 +48,7 @@ def test_multiple_inits_switch_context(
     )
     assert global_context.default_fabric() == Fabric.F_XSMALL
     assert global_context.get_pip_packages() == ["tensorflow==2.3.2"]
-    assert global_context.get_active_context() is None
+    assert context.get_active_context() is None
 
     # and when
     layer.init(initialized_project.name)
@@ -56,7 +56,7 @@ def test_multiple_inits_switch_context(
     # then
     with pytest.raises(LayerClientException, match=r"Dataset not found.*"):
         layer.get_dataset(dataset_name).to_pandas()
-    assert global_context.get_active_context() is None
+    assert context.get_active_context() is None
 
     assert (
         len(
@@ -72,6 +72,6 @@ def test_multiple_inits_switch_context(
     )
     assert global_context.default_fabric() is None
     assert global_context.get_pip_packages() is None
-    assert global_context.get_active_context() is None
+    assert context.get_active_context() is None
 
     _cleanup_project(client, project)

--- a/test/e2e/test_function_model_run.py
+++ b/test/e2e/test_function_model_run.py
@@ -1,7 +1,7 @@
 from sklearn.svm import SVC
 
 import layer
-from layer import global_context
+from layer import context
 from layer.contracts.projects import Project
 from test.e2e.assertion_utils import E2ETestAsserter
 from test.e2e.common_scenarios import (
@@ -36,7 +36,7 @@ def test_local_run_succeeds_and_registers_metadata(
     # when
     train_model()
 
-    assert global_context.get_active_context() is None
+    assert context.get_active_context() is None
 
     # then
     mdl = layer.get_model(model_name)
@@ -66,7 +66,7 @@ def test_local_run_with_args_succeeds_and_registers_metadata(
     # when
     train_model("test_arg")
 
-    assert global_context.get_active_context() is None
+    assert context.get_active_context() is None
 
     # then
     mdl = layer.get_model(model_name)

--- a/test/e2e/test_guest_user_reads.py
+++ b/test/e2e/test_guest_user_reads.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 import layer
-from layer import global_context
+from layer import context
 from layer.clients.layer import LayerClient
 from layer.contracts.assets import AssetPath, AssetType
 from layer.contracts.logged_data import LoggedDataType
@@ -55,7 +55,7 @@ def populated_project(initialized_project: Project) -> Project:
     prepare_data()
     train_model()
 
-    assert global_context.get_active_context() is None
+    assert context.get_active_context() is None
 
     return initialized_project
 

--- a/test/unit/test_context.py
+++ b/test/unit/test_context.py
@@ -1,0 +1,16 @@
+from layer import Context
+from layer.context import get_active_context, reset_active_context, set_active_context
+from layer.contracts.asset import AssetType
+
+
+class TestContext:
+    def test_correct_context_returned(self) -> None:
+        assert get_active_context() is None
+        ctx = Context(
+            asset_name="the-model",
+            asset_type=AssetType.MODEL,
+        )
+        set_active_context(ctx)
+        assert get_active_context() == ctx
+        reset_active_context()
+        assert get_active_context() is None

--- a/test/unit/test_global_context.py
+++ b/test/unit/test_global_context.py
@@ -1,15 +1,11 @@
-from layer import Context
-from layer.contracts.asset import AssetType
 from layer.contracts.fabrics import Fabric
 from layer.global_context import (
     current_account_name,
     current_project_full_name,
     default_fabric,
-    get_active_context,
     get_pip_packages,
     get_pip_requirements_file,
     reset_to,
-    set_active_context,
     set_current_project_full_name,
     set_default_fabric,
     set_pip_packages,
@@ -18,15 +14,6 @@ from layer.global_context import (
 
 
 class TestGlobalContext:
-    def test_correct_context_returned(self) -> None:
-        assert get_active_context() is None
-        ctx = Context(
-            asset_name="the-model",
-            asset_type=AssetType.MODEL,
-        )
-        set_active_context(ctx)
-        assert get_active_context() == ctx
-
     def test_last_project_name_returned(self) -> None:
         set_current_project_full_name("acc/test")
         set_current_project_full_name("acc/anotherTest")

--- a/test/unit/test_global_context.py
+++ b/test/unit/test_global_context.py
@@ -1,4 +1,5 @@
 from layer import Context
+from layer.contracts.asset import AssetType
 from layer.contracts.fabrics import Fabric
 from layer.global_context import (
     current_account_name,
@@ -19,7 +20,10 @@ from layer.global_context import (
 class TestGlobalContext:
     def test_correct_context_returned(self) -> None:
         assert get_active_context() is None
-        ctx = Context()
+        ctx = Context(
+            asset_name="the-model",
+            asset_type=AssetType.MODEL,
+        )
         set_active_context(ctx)
         assert get_active_context() == ctx
 


### PR DESCRIPTION
We want to give users contextual methods similar to the ones available inside a decorated layer function.
The end goal is to offer:
```python

def run_experiment():
  context = layer.get_context()
  train_url = context.get_url()
  context.log({key:value})
  # or layer.log({key: value})

with layer.model("my-model"):
  run_experiment()
```
so that we are very close to Layer function executions
```python
@layer.model("my-model")
def run_experiment():
  train_url = context.get_url()
  layer.log({key:value})
```

This will help users a lot when they dont want to use decorators

## Next PRs
- [ ] do `set_active_context` and `reset_active_context` inside `__enter__` and `__exit__` instead of relying on clients to do it
- [ ] add `get_url()` to context 
- 