### PR TITLE
Force e2e tests to use the function execution system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifdef CI
 	$(eval DATADOG_ARGS := --ddtrace-patch-all --ddtrace)
 endif
 	LAYER_DEFAULT_PATH=$(E2E_TEST_HOME) SDK_E2E_TESTS_LOGS_DIR=$(E2E_TEST_HOME)/stdout-logs/ $(POETRY) run python build_scripts/sdk_login.py $(TEST_TOKEN_FILE)
-	LAYER_DEFAULT_PATH=$(E2E_TEST_HOME) SDK_E2E_TESTS_LOGS_DIR=$(E2E_TEST_HOME)/stdout-logs/ $(POETRY) run pytest $(E2E_TEST_SELECTOR) -s -n $(E2E_TEST_PARALLELISM) -vv $(DATADOG_ARGS)
+	LAYER_DEFAULT_PATH=$(E2E_TEST_HOME) LAYER_EXECUTABLES=True SDK_E2E_TESTS_LOGS_DIR=$(E2E_TEST_HOME)/stdout-logs/ $(POETRY) run pytest $(E2E_TEST_SELECTOR) -s -n $(E2E_TEST_PARALLELISM) -vv $(DATADOG_ARGS)
 
 .PHONY: colab-test
 colab-test: ## Run colab test against image pulled from dockerhub


### PR DESCRIPTION
This PR enables running the e2e tests using the new function execution system to ensure that all the tests are passing against the new implementation.