### PR TITLE
Fail fast when running on Windows without WSL

### DIFF
--- a/layer/main/utils.py
+++ b/layer/main/utils.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Any, Callable
 
 from .version import check_latest_version
@@ -5,7 +6,27 @@ from .version import check_latest_version
 
 def sdk_function(func: Callable[..., Any]) -> Callable[..., Any]:
     def inner(*args: Any, **kwargs: Any) -> Any:
+        _check_os()
         check_latest_version()
         return func(*args, **kwargs)
 
     return inner
+
+
+def _check_os() -> None:
+    import platform
+
+    def is_windows_os() -> bool:
+        return platform.system() == "Windows"
+
+    def is_windows_wsl() -> bool:
+        return (
+            "microsoft" in platform.uname().version
+            or "microsoft" in platform.uname().release
+        )
+
+    if is_windows_os():
+        print(
+            "Windows is not supported. Please, have a look at https://docs.app.layer.ai/docs/installation"
+        )
+        sys.exit()

--- a/layer/main/utils.py
+++ b/layer/main/utils.py
@@ -19,12 +19,6 @@ def _check_os() -> None:
     def is_windows_os() -> bool:
         return platform.system() == "Windows"
 
-    def is_windows_wsl() -> bool:
-        return (
-            "microsoft" in platform.uname().version
-            or "microsoft" in platform.uname().release
-        )
-
     if is_windows_os():
         print(
             "Windows is not supported. Please, have a look at https://docs.app.layer.ai/docs/installation"


### PR DESCRIPTION
Stop execution when trying to run the SDK on Windows without using WSL.