### PR TITLE
Flip the feature flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifdef CI
 	$(eval DATADOG_ARGS := --ddtrace-patch-all --ddtrace)
 endif
 	LAYER_DEFAULT_PATH=$(E2E_TEST_HOME) SDK_E2E_TESTS_LOGS_DIR=$(E2E_TEST_HOME)/stdout-logs/ $(POETRY) run python build_scripts/sdk_login.py $(TEST_TOKEN_FILE)
-	LAYER_DEFAULT_PATH=$(E2E_TEST_HOME) LAYER_EXECUTABLES=True SDK_E2E_TESTS_LOGS_DIR=$(E2E_TEST_HOME)/stdout-logs/ $(POETRY) run pytest $(E2E_TEST_SELECTOR) -s -n $(E2E_TEST_PARALLELISM) -vv $(DATADOG_ARGS)
+	LAYER_DEFAULT_PATH=$(E2E_TEST_HOME) SDK_E2E_TESTS_LOGS_DIR=$(E2E_TEST_HOME)/stdout-logs/ $(POETRY) run pytest $(E2E_TEST_SELECTOR) -s -n $(E2E_TEST_PARALLELISM) -vv $(DATADOG_ARGS)
 
 .PHONY: colab-test
 colab-test: ## Run colab test against image pulled from dockerhub

--- a/layer/config/__init__.py
+++ b/layer/config/__init__.py
@@ -27,5 +27,5 @@ def is_executables_feature_active() -> bool:
     return True
 
 
-def _str2bool(v) -> bool:
+def _str2bool(v: str) -> bool:
     return v.lower() not in ("no", "false", "0")

--- a/layer/config/__init__.py
+++ b/layer/config/__init__.py
@@ -19,13 +19,13 @@ from .config_manager import ConfigManager  # noqa
 def is_executables_feature_active() -> bool:
     import os
 
-    if "LAYER_EXECUTABLES" in os.environ:
-        return True
-
-    try:
-        config = ConfigManager().load()
-    except:  # noqa
+    if "LAYER_EXECUTABLES" in os.environ and not _str2bool(
+        os.environ["LAYER_EXECUTABLES"]
+    ):
         return False
+    # enabled by default
+    return True
 
-    # enable by default for non production environments
-    return config.url != DEFAULT_URL
+
+def _str2bool(v) -> bool:
+    return v.lower() not in ("no", "false", "0")

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -255,7 +255,7 @@ class TestIsExecutablesFeatureActive:
     @pytest.mark.parametrize(
         "config_url,flag_enabled",
         [
-            ("https://app.layer.ai", False),
+            ("https://app.layer.ai", True),
             ("https://dev1.layer.ai", True),
             ("https://dev2.layer.ai", True),
             ("https://app.layer.co", True),
@@ -281,3 +281,7 @@ class TestIsExecutablesFeatureActive:
     def test_active_by_env_var(self):
         with patch.dict("os.environ", {"LAYER_EXECUTABLES": "1"}):
             assert is_executables_feature_active()
+
+    def test_disabled_by_env_var(self):
+        with patch.dict("os.environ", {"LAYER_EXECUTABLES": "false"}):
+            assert not is_executables_feature_active()


### PR DESCRIPTION
Makes the function executable feature flag true by default but user override-able by explicitly setting it to `False`.

Let's chose between this option and https://github.com/layerai/sdk/pull/365 
@dpp23 @volkangurel 