### PR TITLE
Enable renovate dependency dashboard

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,4 +1,5 @@
 {
+  dependencyDashboard: true,
   packageRules: [
     {
       matchPackagePatterns: ["*"],


### PR DESCRIPTION
The dashboard is useful to trigger renovate to run on demand.

This will create a permanent issue with the list of dependencies Renovate manages. We will be able to trigger it to run by ticking a tickbox there.