### PR TITLE
Always fallback to psutil for system metrics on local runs

### DIFF
--- a/layer/logged_data/system_metrics.py
+++ b/layer/logged_data/system_metrics.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import subprocess  # nosec: import_subprocess
 import threading
@@ -193,7 +194,7 @@ class SystemMetrics:
         )
 
         # By default, we get metrics from psutil
-        if DockerMetricsCollector.METRICS_ROOT.exists():
+        if "LAYER_FABRIC" in os.environ:
             self._metrics_collector = DockerMetricsCollector(self._logger)
         else:
             self._metrics_collector = PsUtilMetricsCollector(self._logger)


### PR DESCRIPTION
On Ubuntu 22.04, we fail when we try to parse `cgroups` data to determine system metrics. Until we fix it, ensure we always use `psutil` if on a remote run.