### PR TITLE
Bundle local sdk version in executable package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,8 +262,8 @@ To run this test you will need to generate an API KEY and provide via the termin
 ##### Testing your local SDK build within a Google Colab notebook
 
 1. Run `poetry build`
-2. Upload `dist/layer-0.10.0-py3-none-any.whl` to the Colab notebook after a runtime recreation (hint: you can do by `from google.colab import files` and `files.upload()` inside Colab)
-3. `pip install layer-0.10.0-py3-none-any.whl`
+2. Upload `dist/layer-0.10.0b1-py3-none-any.whl` to the Colab notebook after a runtime recreation (hint: you can do by `from google.colab import files` and `files.upload()` inside Colab)
+3. `pip install layer-0.10.0b1-py3-none-any.whl`
 4. Run the rest of the notebook as normal
 
 #### Linters

--- a/layer/executables/packager.py
+++ b/layer/executables/packager.py
@@ -11,7 +11,6 @@ import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, Optional, Sequence, Tuple
-from xmlrpc.client import Boolean
 
 import layer
 from layer.contracts.conda import CondaEnv
@@ -109,7 +108,7 @@ def get_function_package_info(package_path: Path) -> FunctionPackageInfo:
     )
 
 
-def _is_dev_version() -> Boolean:
+def _is_dev_version() -> bool:
     return layer.__version__ == "0.10.0b1"
 
 

--- a/layer/executables/packager.py
+++ b/layer/executables/packager.py
@@ -115,7 +115,7 @@ def _is_version_on_pypi() -> Boolean:
     version = layer.__version__
     pypi_url = f"https://pypi.org/pypi/layer/{version}/json"
     try:
-        urllib.request.urlopen(pypi_url)
+        urllib.request.urlopen(pypi_url)  # nosec urllib_urlopen
     except urllib.error.HTTPError:
         return False
     return True

--- a/layer/main/version.py
+++ b/layer/main/version.py
@@ -20,7 +20,7 @@ def get_version() -> str:
     ) as pyproject:
         text = pyproject.read()
         # Use a simple regex to avoid a dependency on toml
-        version_match = re.search(r'version = "(\d+\.\d+\.\d+)"', text)
+        version_match = re.search(r'version = "(\d+\.\d+\.\d+.*)"', text)
 
     if version_match is None:
         raise RuntimeError("Failed to parse version")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "layer"
-version = "0.10.0"
+version = "0.10.0b1"
 description = "Layer AI SDK"
 authors = ["Layer <info@layer.ai>"]
 readme = "README.md"

--- a/test/colab/test_import_login_init.ipynb
+++ b/test/colab/test_import_login_init.ipynb
@@ -13,7 +13,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install ../../dist/layer-0.10.0-py3-none-any.whl"
+        "!pip install ../../dist/layer-0.10.0b1-py3-none-any.whl"
       ]
     },
     {
@@ -43,17 +43,17 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3.9.13 ('base')",
+      "display_name": "Python 3.8.13 ('layer-YHuFjZ3r-py3.8')",
       "language": "python",
       "name": "python3"
     },
     "language_info": {
       "name": "python",
-      "version": "3.9.13"
+      "version": "3.8.13"
     },
     "vscode": {
       "interpreter": {
-        "hash": "f707039e2930c7fdd2d83f5c382f05e243d5d00d991436b6fe258cf3e2f688fc"
+        "hash": "cac02caba0580aa41d061132e1fcfe49c99980ef20b736d57f6eddb8b57cba8e"
       }
     }
   },

--- a/test/unit/executables/test_packager.py
+++ b/test/unit/executables/test_packager.py
@@ -6,6 +6,7 @@ from pathlib import Path, PurePath
 
 import pytest
 
+import layer
 from layer.contracts.conda import CondaEnv
 from layer.executables.packager import (
     FunctionPackageInfo,
@@ -30,7 +31,7 @@ def test_execute_func_simple_as_python_script(tmpdir: Path):
     subprocess.check_call([sys.executable, executable])
 
 
-def test_package_contents(tmpdir: Path):
+def test_package_contents(tmpdir: Path, monkeypatch: pytest.MonkeyPatch):
     resources_parent = Path("test") / "unit" / "executables" / "data"
     resource_paths = [
         resources_parent / "1",
@@ -41,7 +42,11 @@ def test_package_contents(tmpdir: Path):
     def func():
         pass
 
-    executable = package_function(func, resources=resource_paths, output_dir=tmpdir)
+    layer_version = "1.2.3"
+    with monkeypatch.context() as m:
+        m.setattr(layer.executables.packager, "_is_version_on_pypi", lambda: True)
+        m.setattr(layer, "__version__", layer_version)
+        executable = package_function(func, resources=resource_paths, output_dir=tmpdir)
 
     with zipfile.ZipFile(executable) as exec:
         exec_entries = {entry.filename for entry in exec.infolist()}
@@ -68,7 +73,35 @@ def test_package_contents(tmpdir: Path):
             "cloudpickle/cloudpickle.py",
             "cloudpickle/cloudpickle_fast.py",
             "cloudpickle/compat.py",
+            "layer.txt",
         }
+
+        with exec.open("layer.txt") as layer_txt:
+            assert layer_txt.read().decode("utf-8") == f"layer=={layer_version}"
+
+
+def test_package_contents_local_version(tmpdir: Path, monkeypatch: pytest.MonkeyPatch):
+    def func():
+        pass
+
+    with monkeypatch.context() as m:
+        m.setattr(layer.executables.packager, "_is_version_on_pypi", lambda: False)
+        executable = package_function(func, output_dir=tmpdir)
+
+    with zipfile.ZipFile(executable) as exec:
+        exec_entries = {entry.filename for entry in exec.infolist()}
+        assert exec_entries.issuperset(
+            {
+                "layer-sdk/",
+                "layer-sdk/layer/",
+                "layer-sdk/pyproject.toml",
+                "layer-sdk/README.md",
+                "layer.txt",
+            }
+        )
+
+        with exec.open("layer.txt") as layer_txt:
+            assert layer_txt.read().decode("utf-8") == "./layer-sdk"
 
 
 def test_get_function_package_info_with_pip_dependencies(tmpdir: Path):

--- a/test/unit/executables/test_packager.py
+++ b/test/unit/executables/test_packager.py
@@ -44,7 +44,6 @@ def test_package_contents(tmpdir: Path, monkeypatch: pytest.MonkeyPatch):
 
     layer_version = "1.2.3"
     with monkeypatch.context() as m:
-        m.setattr(layer.executables.packager, "_is_version_on_pypi", lambda: True)
         m.setattr(layer, "__version__", layer_version)
         executable = package_function(func, resources=resource_paths, output_dir=tmpdir)
 
@@ -80,13 +79,11 @@ def test_package_contents(tmpdir: Path, monkeypatch: pytest.MonkeyPatch):
             assert layer_txt.read().decode("utf-8") == f"layer=={layer_version}"
 
 
-def test_package_contents_local_version(tmpdir: Path, monkeypatch: pytest.MonkeyPatch):
+def test_package_contents_dev_version(tmpdir: Path):
     def func():
         pass
 
-    with monkeypatch.context() as m:
-        m.setattr(layer.executables.packager, "_is_version_on_pypi", lambda: False)
-        executable = package_function(func, output_dir=tmpdir)
+    executable = package_function(func, output_dir=tmpdir)
 
     with zipfile.ZipFile(executable) as exec:
         exec_entries = {entry.filename for entry in exec.infolist()}


### PR DESCRIPTION
In order to be able to be able to install the same version as the client side inside the remote executors.

In production, this means adding a file with the requirement `layer==1.2.3`, in development this means copying the local sdk code so we can install from source.