### PR TITLE
Delete old test org accounts before running e2e tests

### DIFF
--- a/layer/clients/account_service.py
+++ b/layer/clients/account_service.py
@@ -1,11 +1,16 @@
+import datetime
 import uuid
 from typing import Optional
 
+import layerapi.api.value.date_pb2
+from layerapi.api.entity.account_pb2 import Account as PbAccount
 from layerapi.api.entity.account_view_pb2 import AccountView
 from layerapi.api.ids_pb2 import AccountId
 from layerapi.api.service.account.account_api_pb2 import (
     CreateOrganizationAccountRequest,
     DeleteAccountRequest,
+    GetAccountByIdRequest,
+    GetAccountByIdResponse,
     GetAccountViewByIdRequest,
     GetMyAccountViewRequest,
 )
@@ -68,3 +73,17 @@ class AccountServiceClient:
         self._account_api.DeleteAccount(
             DeleteAccountRequest(account_id=AccountId(value=str(account_id)))
         )
+
+    def get_account_creation_date(self, account_id: uuid.UUID) -> datetime.datetime:
+        resp: GetAccountByIdResponse = self._account_api.GetAccountById(
+            GetAccountByIdRequest(account_id=AccountId(value=str(account_id)))
+        )
+        acc: PbAccount = resp.account
+        created_date: layerapi.api.value.date_pb2.Date = acc.created_date
+        date = datetime.datetime(
+            created_date.year_month.year,
+            created_date.year_month.month,
+            created_date.day,
+            tzinfo=datetime.timezone.utc,
+        )
+        return date

--- a/test/unit/config/test_config.py
+++ b/test/unit/config/test_config.py
@@ -1,0 +1,28 @@
+import uuid
+
+import jwt
+
+from layer.config import ClientConfig
+
+
+class TestClientConfig:
+    def test_gives_correct_organization_account_ids(self) -> None:
+        personal_account_id = uuid.uuid4()
+        org_account_id_1 = uuid.uuid4()
+        org_account_id_2 = uuid.uuid4()
+        layer_claim_prefix = "https://layer.co"
+        payload = {
+            f"{layer_claim_prefix}/account_id": str(personal_account_id),
+            f"{layer_claim_prefix}/account_permissions": {
+                str(org_account_id_1): ["read", "write"],
+                str(org_account_id_2): ["read"],
+            },
+        }
+        token = str(jwt.encode(payload, "secret", algorithm="HS256"))
+
+        cfg = ClientConfig(access_token=token)
+
+        ids = cfg.organization_account_ids()
+        assert len(ids) == 2
+        assert cfg.personal_account_id() == personal_account_id
+        assert personal_account_id not in ids


### PR DESCRIPTION
Current API only gives the date without the time, so accounts older than one day are removed.

If we want older than one hour, we need to the update account api first to support more precise datetime.