### PR TITLE
Preserve signature of sdk functions

### DIFF
--- a/layer/main/utils.py
+++ b/layer/main/utils.py
@@ -1,3 +1,4 @@
+import functools
 import sys
 from typing import Any, Callable
 
@@ -5,6 +6,7 @@ from .version import check_latest_version
 
 
 def sdk_function(func: Callable[..., Any]) -> Callable[..., Any]:
+    @functools.wraps(func)
     def inner(*args: Any, **kwargs: Any) -> Any:
         _check_os()
         check_latest_version()


### PR DESCRIPTION
All sdk functions currently show as `Any->Any` as the `sdk_function` decorator masks their signature. This has also broken the automatic docs generation.