### PR TITLE
Fix cgroups parsing on Ubuntu 22.04

### DIFF
--- a/layer/logged_data/system_metrics.py
+++ b/layer/logged_data/system_metrics.py
@@ -157,7 +157,7 @@ class CGroupsMetricsCollectorVersionedV2(CGroupsMetricsCollectorVersioned):
 
     def get_mem_available(self) -> int:
         memory_high = self._read_cgroup_metric("user.slice/memory.high")
-        if memory_high == "max":
+        if memory_high.strip() == "max":
             return int(psutil.virtual_memory().total)
         else:
             return int(memory_high)


### PR DESCRIPTION
On my machine, `user.slice/memory.high` seems to have an extra empty line at the end of the file so the string comparison was failing.