### PR TITLE
Only check lockfile if there is a chance it is broken

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,7 +40,16 @@ jobs:
           path: /home/runner/.cache/pypoetry/virtualenvs
           key: poetry-venvs-${{ runner.os }}-3.8-${{ hashFiles('poetry.lock') }}
           restore-keys: poetry-vevns-${{ runner.os }}-3.8-
+      - name: Get changes that affect the lockfile
+        id: changed-files
+        uses: tj-actions/changed-files@v19.1
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          files: |
+           pyproject.toml
+           poetry.lock
       - name: Check lockfile
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           pip install yq
           old_hash=$(cat poetry.lock | tomlq '.metadata["content-hash"]' --raw-output)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,16 @@ jobs:
           path: /home/runner/.cache/pypoetry/virtualenvs
           key: poetry-venvs-${{ runner.os }}-3.8-${{ hashFiles('poetry.lock') }}
           restore-keys: poetry-venvs-${{ runner.os }}-3.8-
+      - name: Get changes that affect the lockfile
+        id: changed-files-lockfile
+        uses: tj-actions/changed-files@v19.1
+        with:
+          base_sha: ${{ github.event.before }}
+          files: |
+           pyproject.toml
+           poetry.lock
       - name: Check lockfile
+        if: steps.changed-files-lockfile.outputs.any_changed == 'true'
         run: |
           pip install yq
           old_hash=$(cat poetry.lock | tomlq '.metadata["content-hash"]' --raw-output)


### PR DESCRIPTION
Lockfile checks can take up to 15 mins these days. They will go away with poetry 1.2, but this is currently blocked.

For now, just not run the check unless `pyproject,toml` or the lockfile have changes, that should solve the problem for the majority of the PRs.