### PR TITLE
[LAY-3768] Rewire error reporting for Dataset build

### DIFF
--- a/layer/clients/data_catalog.py
+++ b/layer/clients/data_catalog.py
@@ -324,6 +324,12 @@ class DataCatalogClient:
         )
         return dataset_proto_mapper.from_dataset_build(build, version)
 
+    def get_build_info_by_build_id(self, id_: uuid.UUID) -> Optional[str]:
+        build = self._get_build_by_id(str(id_))
+        if build.build_info:
+            return build.build_info.info
+        return None
+
     def _get_dataset_by_id(self, id_: str) -> PBDataset:
         return self._service.GetDataset(
             GetDatasetRequest(dataset_id=DatasetId(value=id_)),

--- a/layer/exceptions/status_report.py
+++ b/layer/exceptions/status_report.py
@@ -126,6 +126,10 @@ class AssertionFailureStatusReport(ExecutionStatusReport):
 
 class ExecutionStatusReportFactory:
     @staticmethod
+    def from_plain_text(message: str) -> ExecutionStatusReport:
+        return GenericExecutionStatusReport(message)
+
+    @staticmethod
     def from_json(json_str: str) -> ExecutionStatusReport:
         try:
             payload = json.loads(json_str)


### PR DESCRIPTION
Application-level errors resulting from the Dataset Build process are reported to the metadata store.
We want to display those specific errors to the user in a concise way. 
This PR "rewires" the Dataset Build result into the error reporting, falling back onto the job log in case we don't have a status.
(which could be the case for OOM errors, for example)

Model train will be done separately because we need an [extra endpoint in the backend](https://linear.app/layer/issue/LAY-3770/model-catalog-should-offer-a-getmodeltrainstatus-endpoint) to use the same method exploited here.