### PR TITLE
Allow logging data only for runs

### DIFF
--- a/layer/logged_data/log_data_runner.py
+++ b/layer/logged_data/log_data_runner.py
@@ -37,8 +37,10 @@ class LogDataRunner:
         train_id: Optional[UUID] = None,
         dataset_build_id: Optional[UUID] = None,
         logger: Optional[Logger] = None,
+        feature_enabled_runs: bool = False,
     ):
-        assert bool(train_id) ^ bool(dataset_build_id)
+        if not feature_enabled_runs:
+            assert bool(train_id) ^ bool(dataset_build_id)
         self._run_id = run_id
         self._train_id = train_id
         self._dataset_build_id = dataset_build_id


### PR DESCRIPTION
By setting the env variable 'LAYER_FEATURE_RUNS=True', we can now do
```
layer.init("my-project", labels=["l1"])
layer.log({"key": 1.0})
```